### PR TITLE
Compile git with cURL to enable HTTP(S) transport

### DIFF
--- a/recipes/devel/bootstrap-sandbox.yaml
+++ b/recipes/devel/bootstrap-sandbox.yaml
@@ -26,7 +26,7 @@ depends:
     - devel::makedepend
     - devel::patch
     - libs::gettext
-    - net::curl
+    - net::curl-tgt
     - net::make-ca
     - net::openssh
     - perl::perl

--- a/recipes/devel/git.yaml
+++ b/recipes/devel/git.yaml
@@ -6,11 +6,13 @@ metaEnvironment:
 depends:
     - libs::zlib-dev
     - libs::openssl-dev
+    - net::curl-dev
 
     - use: []
       depends:
         - libs::zlib-tgt
         - libs::openssl-tgt
+        - net::curl-tgt
 
 checkoutSCM:
     scm: url
@@ -23,13 +25,17 @@ buildVars: [PKG_VERSION, AUTOCONF_HOST,
     CPPFLAGS, CFLAGS, LDFLAGS]
 buildScript: |
     export CFLAGS="-I${BOB_DEP_PATHS[libs::zlib-dev]}/usr/include -I${BOB_DEP_PATHS[libs::openssl-dev]}/usr/include"
-    export LDFLAGS="-L${BOB_DEP_PATHS[libs::zlib-dev]}/usr/lib -L${BOB_DEP_PATHS[libs::openssl-dev]}/usr/lib"
+    export LDFLAGS="-L${BOB_DEP_PATHS[libs::zlib-dev]}/usr/lib -L${BOB_DEP_PATHS[libs::openssl-dev]}/usr/lib -Wl,-rpath-link=${BOB_DEP_PATHS[libs::zlib-dev]}/usr/lib -Wl,-rpath-link=${BOB_DEP_PATHS[libs::openssl-dev]}/usr/lib"
 
     mkdir -p install
     tar -xzf $1/git-${PKG_VERSION}.tar.gz
 
     pushd git-${PKG_VERSION}
-    ./configure --host=${AUTOCONF_HOST} --prefix=/usr --without-python --without-expat
+    ./configure --host=${AUTOCONF_HOST} \
+                --prefix=/usr \
+                --with-curl=${BOB_DEP_PATHS[net::curl-dev]}/usr \
+                --without-python \
+                --without-expat
     makeParallel
     make DESTDIR=${PWD}/../install install
     popd

--- a/recipes/devel/sandbox.yaml
+++ b/recipes/devel/sandbox.yaml
@@ -52,7 +52,7 @@ depends:
     - devel::texinfo
     - kernel::kmod
     - libs::gettext
-    - net::curl
+    - net::curl-tgt
     - net::make-ca
     - net::openssh
     - perl::perl

--- a/recipes/net/curl.yaml
+++ b/recipes/net/curl.yaml
@@ -30,7 +30,11 @@ buildScript: |
        --with-ssl \
        --with-ca-path=/etc/ssl/certs
 
-packageScript: |
-    autotoolsPackageTgt
+multiPackage:
+    dev:
+        packageScript: autotoolsPackageDev
+        provideDeps: [ "*-dev" ]
 
-provideDeps: [ "*-tgt" ]
+    tgt:
+        packageScript: autotoolsPackageTgt
+        provideDeps: [ "*-tgt" ]


### PR DESCRIPTION
Without these changes building the embedded example failed to build with the error message:

```
   CHECKOUT  work/demo/echo-chamber/src/1/workspace
fatal: Unable to find remote helper for 'https'
Step failed with return status 128; Command: git fetch -p origin
Call stack (most recent call first)
    #0: Recipe demo::echo-chamber in checkoutSCM: dir:., url:https://github.com/BobBuildTool/bob-example-embedded-echo-chamber.git, line 29, in main
Build error: Build script ./work/demo/echo-chamber/src/1/checkout.sh returned with 128
Failed package: demo::linux+freertos/demo::vexpress/demo::initramfs/demo::echo-chamber
```

Afterwards, the checkout works fine:

```
   CHECKOUT  work/demo/echo-chamber/src/1/workspace
From https://github.com/BobBuildTool/bob-example-embedded-echo-chamber
 * [new branch]      master     -> origin/master
Already on 'master'
```