### PR TITLE
libs/gdbm: enabled libgdbm compat

### DIFF
--- a/recipes/libs/gdbm.yaml
+++ b/recipes/libs/gdbm.yaml
@@ -10,7 +10,8 @@ checkoutSCM:
     stripComponents: 1
 
 buildScript: |
-    autotoolsBuild $1
+    autotoolsBuild $1 \
+        --enable-libgdbm-compat
 
 multiPackage:
     dev:


### PR DESCRIPTION
* prerequisite for other packages like python-dev