### PR TITLE
libs/ncurses: enabled widec, added BASEMENT_LIBS (static/shared) switch, small bugfixes

### DIFF
--- a/recipes/libs/ncurses.yaml
+++ b/recipes/libs/ncurses.yaml
@@ -62,6 +62,7 @@ buildScript: |
             --enable-const          \
             --enable-overwrite      \
             --enable-pc-files       \
+            --enable-widec          \
             --disable-stripping     \
             --with-pkg-config-libdir="/usr/lib/pkgconfig" \
             --without-manpages

--- a/recipes/libs/ncurses.yaml
+++ b/recipes/libs/ncurses.yaml
@@ -14,7 +14,7 @@ buildScript: |
     # We need to pass the path of the just built tic
     # able to run on the building machine, so that the
     # terminal database can be created without errors.
-    mkdir tic
+    mkdir -p tic
     pushd tic
     $1/configure
     make -C include
@@ -47,7 +47,7 @@ multiPackage:
     dev:
         packageScript: |
             autotoolsPackageDev "$1" \
-               /usr /usr/bin /usr/bin "/usr/bin/ncurses*-config"
+               "/usr/" "/usr/bin/" "/usr/bin/ncurses*-config"
     tgt:
         packageScript: |
             autotoolsPackageTgt

--- a/recipes/libs/ncurses.yaml
+++ b/recipes/libs/ncurses.yaml
@@ -10,6 +10,7 @@ checkoutSCM:
     stripComponents: 1
 
 buildTools: [host-toolchain]
+buildVars: [BASEMENT_LIBS]
 buildScript: |
     # We need to pass the path of the just built tic
     # able to run on the building machine, so that the
@@ -22,10 +23,32 @@ buildScript: |
     export TIC_PATH=$(pwd)/progs/tic
     popd
 
+    OPTS=( )
+    if [[ -n "${BASEMENT_LIBS:-}" ]] ; then
+        case "$BASEMENT_LIBS" in
+            static)
+                OPTS=( --without-shared --with-normal )
+                ;;
+            shared)
+                OPTS=( --with-shared --without-normal )
+                ;;
+            both)
+                OPTS=( --with-shared --with-normal )
+                ;;
+            *)
+                echo "Invalid BASEMENT_LIBS value: $BASEMENT_LIBS" >&2
+                exit 1
+                ;;
+        esac
+    elif [[ "${AUTOCONF_BUILD:-unknown}" != "${AUTOCONF_HOST:-${AUTOCONF_BUILD:-unknown}}" ]]; then
+        OPTS=( --without-shared --with-normal )
+    else
+        OPTS=( --with-shared --without-normal )
+    fi
+
     autotoolsBuild $1 \
-            --with-shared           \
+            ${OPTS[@]}              \
             --without-debug         \
-            --without-normal        \
             --without-cxx           \
             --without-cxx-binding   \
             --without-ada           \


### PR DESCRIPTION
* widec is prerequisite for for other packages, e.g. python3-dev