### PR TITLE
classes/cmake: fixed typo, missing S for MAKE_TARGETS

### DIFF
--- a/classes/cmake.yaml
+++ b/classes/cmake.yaml
@@ -129,7 +129,7 @@ buildScript: |
             "${@:2}"
 
         ninjaParallel ${MAKE_OPTIONS:+"${MAKE_OPTIONS[@]}"} \
-            ${MAKE_TARGETS:+"${MAKE_TARGET[@]}"}
+            ${MAKE_TARGETS:+"${MAKE_TARGETS[@]}"}
 
         if [[ -n "$INSTALL" ]] ; then
             DESTDIR="${PWD}/../install" cmake \


### PR DESCRIPTION
Fix for #63 