### PR TITLE
libs/glib: remove bindir prefix in pc files

### DIFF
--- a/recipes/libs/glib.yaml
+++ b/recipes/libs/glib.yaml
@@ -24,6 +24,9 @@ checkoutScript: |
 
 buildScript: |
     mesonBuild $1 -Dtests=false
+    pushd install/usr/lib/pkgconfig
+    sed -i 's/\${bindir}\///g' glib-2.0.pc gio-2.0.pc
+    popd
 
 multiPackage:
     dev:


### PR DESCRIPTION
to resolve tools like glib-mkenums by PATH

fix for #74