### PR TITLE
libs/expat: update to v2.3.0, because v2.1.0 was removed from official

### DIFF
--- a/recipes/libs/expat.yaml
+++ b/recipes/libs/expat.yaml
@@ -1,12 +1,12 @@
 inherit: [autotools]
 
 metaEnvironment:
-   PKG_VERSION: "2.1.0"
+   PKG_VERSION: "2.3.0"
 
 checkoutSCM:
    scm: url
    url: http://downloads.sourceforge.net/project/expat/expat/${PKG_VERSION}/expat-${PKG_VERSION}.tar.gz
-   digestSHA1: "b08197d146930a5543a7b99e871cba3da614f6f0"
+   digestSHA256: 89df123c62f2c2e2b235692d9fe76def6a9ab03dbe95835345bf412726eb1987
    stripComponents: 1
 
 buildScript: |


### PR DESCRIPTION
source: "RENAMED-VULNERABLE-PLEASE-USE-2.3.0-INSTEAD"