### PR TITLE
recipes: mirror variable for some common sources urls

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -1,5 +1,9 @@
 environment:
     GNU_MIRROR: "http://ftp.gnu.org/pub/gnu"
+    GITHUB_MIRROR: "https://github.com"
+    KERNEL_MIRROR: "https://cdn.kernel.org/pub"
+    SOURCEFORGE_MIRROR: "https://downloads.sourceforge.net"
+    SOURCEWARE_MIRROR: "https://sourceware.org/pub"
 
     # default compile flags
     BASEMENT_OPTIMIZE: "s" # compiler optimization level (0/1/2/s)

--- a/recipes/core/util-linux.yaml
+++ b/recipes/core/util-linux.yaml
@@ -15,7 +15,7 @@ depends:
 
 checkoutSCM:
     scm: url
-    url: https://www.kernel.org/pub/linux/utils/util-linux/v${PKG_VERSION_MAJOR}/util-linux-${PKG_VERSION}.tar.xz
+    url: ${KERNEL_MIRROR}/linux/utils/util-linux/v${PKG_VERSION_MAJOR}/util-linux-${PKG_VERSION}.tar.xz
     digestSHA256: "21b7431e82f6bcd9441a01beeec3d57ed33ee948f8a5b41da577073c372eb58a"
     stripComponents: 1
 

--- a/recipes/devel/cmake.yaml
+++ b/recipes/devel/cmake.yaml
@@ -5,7 +5,7 @@ metaEnvironment:
 
 checkoutSCM:
     scm: url
-    url: https://github.com/Kitware/CMake/releases/download/v${PKG_VERSION}/cmake-${PKG_VERSION}.tar.gz
+    url: ${GITHUB_MIRROR}/Kitware/CMake/releases/download/v${PKG_VERSION}/cmake-${PKG_VERSION}.tar.gz
     digestSHA256: 0bd60d512275dc9f6ef2a2865426a184642ceb3761794e6b65bff233b91d8c40
     stripComponents: 1
 

--- a/recipes/devel/flex.yaml
+++ b/recipes/devel/flex.yaml
@@ -5,7 +5,7 @@ metaEnvironment:
 
 checkoutSCM:
     scm: url
-    url: https://sourceforge.net/projects/flex/files/flex-${PKG_VERSION}.tar.gz
+    url: ${SOURCEFORGE_MIRROR}/flex/flex-${PKG_VERSION}.tar.gz
     digestSHA1: "cfe10b5de4893ced356adc437e78018e715818c3"
     stripComponents: 1
 

--- a/recipes/devel/git.yaml
+++ b/recipes/devel/git.yaml
@@ -16,7 +16,7 @@ depends:
 
 checkoutSCM:
     scm: url
-    url: https://www.kernel.org/pub/software/scm/git/git-${PKG_VERSION}.tar.xz
+    url: ${KERNEL_MIRROR}/software/scm/git/git-${PKG_VERSION}.tar.xz
     digestSHA1: "851537fc03f5a99419ef20e9b836de965c7928bd"
     extract: False
 

--- a/recipes/devel/meson.yaml
+++ b/recipes/devel/meson.yaml
@@ -3,7 +3,7 @@ metaEnvironment:
 
 checkoutSCM:
     scm: url
-    url: https://github.com/mesonbuild/meson/archive/${PKG_VERSION}.tar.gz
+    url: ${GITHUB_MIRROR}/mesonbuild/meson/archive/${PKG_VERSION}.tar.gz
     digestSHA256: a9ca7adf66dc69fbb7e583f7c7aef16b9fe56ec2874a3d58747e69a3affdf300
     extract: false
 

--- a/recipes/devel/ninja.yaml
+++ b/recipes/devel/ninja.yaml
@@ -5,7 +5,7 @@ metaEnvironment:
 
 checkoutSCM:
     scm: url
-    url: https://github.com/Kitware/ninja/archive/v1.10.0.gfb670.kitware.jobserver-1.tar.gz
+    url: ${GITHUB_MIRROR}/Kitware/ninja/archive/v${PKG_VERSION}.tar.gz
     digestSHA256: d00033813993116a4e14f835df813daee9916b107333d88dbb798a22f8671b1f
     stripComponents: 1
 

--- a/recipes/devel/squashfs-tools.yaml
+++ b/recipes/devel/squashfs-tools.yaml
@@ -9,7 +9,7 @@ depends:
 
 checkoutSCM:
     scm: url
-    url: https://github.com/plougher/squashfs-tools/archive/${PKG_VERSION}.tar.gz
+    url: ${GITHUB_MIRROR}/plougher/squashfs-tools/archive/${PKG_VERSION}.tar.gz
     digestSHA256: "a7fa4845e9908523c38d4acf92f8a41fdfcd19def41bd5090d7ad767a6dc75c3"
     stripComponents: 1
 

--- a/recipes/devel/win/cmake.yaml
+++ b/recipes/devel/win/cmake.yaml
@@ -3,7 +3,7 @@ metaEnvironment:
 
 checkoutSCM:
     scm: url
-    url: https://github.com/Kitware/CMake/releases/download/v${PKG_VERSION}/cmake-${PKG_VERSION}-win64-x64.zip
+    url: ${GITHUB_MIRROR}/Kitware/CMake/releases/download/v${PKG_VERSION}/cmake-${PKG_VERSION}-win64-x64.zip
     digestSHA256: 8a02de221aa96c236a947b28ca1bd6327b9bb82fa74b91e5caa49ffd6a642ae2
 
 buildVars: [PKG_VERSION]

--- a/recipes/devel/win/ninja.yaml
+++ b/recipes/devel/win/ninja.yaml
@@ -3,7 +3,7 @@ metaEnvironment:
 
 checkoutSCM:
     scm: url
-    url: https://github.com/ninja-build/ninja/releases/download/v${PKG_VERSION}/ninja-win.zip
+    url: ${GITHUB_MIRROR}/ninja-build/ninja/releases/download/v${PKG_VERSION}/ninja-win.zip
     digestSHA256: 5d1211ea003ec9760ad7f5d313ebf0b659d4ffafa221187d2b4444bc03714a33
 
 buildScript: |

--- a/recipes/kernel/kmod.yaml
+++ b/recipes/kernel/kmod.yaml
@@ -8,7 +8,7 @@ privateEnvironment:
 
 checkoutSCM:
     scm: url
-    url: https://www.kernel.org/pub/linux/utils/kernel/kmod/kmod-${PKG_VERSION}.tar.gz
+    url: ${KERNEL_MIRROR}/linux/utils/kernel/kmod/kmod-${PKG_VERSION}.tar.gz
     digestSHA1: "e07a6245a040e8c18bff39b302d6d09bcbdf57b6"
     stripComponents: 1
 

--- a/recipes/kernel/linux-libc-headers.yaml
+++ b/recipes/kernel/linux-libc-headers.yaml
@@ -15,7 +15,7 @@ metaEnvironment:
 
 checkoutSCM:
     scm: url
-    url: https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-${PKG_VERSION}.tar.xz
+    url: ${KERNEL_MIRROR}/linux/kernel/v5.x/linux-${PKG_VERSION}.tar.xz
     digestSHA1: "07e40057b78f1c9dd2b042056325d99fcf9f8a08"
     stripComponents: 1
 

--- a/recipes/kernel/linux.yaml
+++ b/recipes/kernel/linux.yaml
@@ -15,7 +15,7 @@ metaEnvironment:
 
 checkoutSCM:
     scm: url
-    url: https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-${PKG_VERSION}.tar.xz
+    url: ${KERNEL_MIRROR}/linux/kernel/v5.x/linux-${PKG_VERSION}.tar.xz
     digestSHA1: "3b84ef2105b55549f1d0329f2522741581eea326"
     stripComponents: 1
 

--- a/recipes/libs/compat/glibc.yaml
+++ b/recipes/libs/compat/glibc.yaml
@@ -11,7 +11,7 @@ metaEnvironment:
 
 checkoutSCM:
     scm: url
-    url: http://ftp.gnu.org/gnu/glibc/glibc-${PKG_VERSION}.tar.xz
+    url: ${GNU_MIRROR}/glibc/glibc-${PKG_VERSION}.tar.xz
     digestSHA256: "94efeb00e4603c8546209cefb3e1a50a5315c86fa9b078b6fad758e187ce13e9"
     stripComponents: 1
 

--- a/recipes/libs/elfutils.yaml
+++ b/recipes/libs/elfutils.yaml
@@ -11,7 +11,8 @@ depends:
 
 checkoutSCM:
     scm: url
-    url: https://sourceware.org/elfutils/ftp/${PKG_VERSION}/elfutils-${PKG_VERSION}.tar.bz2
+    url: ${SOURCEWARE_MIRROR}/elfutils/${PKG_VERSION}/elfutils-${PKG_VERSION}.tar.bz2
+    digestSHA256: 25a545566cbacaa37ae6222e58f1c48ea4570f53ba991886e2f5ce96e22a23a2
     stripComponents: 1
 
 buildScript: |

--- a/recipes/libs/expat.yaml
+++ b/recipes/libs/expat.yaml
@@ -5,7 +5,7 @@ metaEnvironment:
 
 checkoutSCM:
    scm: url
-   url: https://github.com/libexpat/libexpat/releases/download/R_$(subst,".","_",${PKG_VERSION})/expat-${PKG_VERSION}.tar.gz
+   url: ${GITHUB_MIRROR}/libexpat/libexpat/releases/download/R_$(subst,".","_",${PKG_VERSION})/expat-${PKG_VERSION}.tar.gz
    digestSHA256: a00ae8a6b96b63a3910ddc1100b1a7ef50dc26dceb65ced18ded31ab392f132b
    stripComponents: 1
 

--- a/recipes/libs/freetype.yaml
+++ b/recipes/libs/freetype.yaml
@@ -12,7 +12,7 @@ depends:
 
 checkoutSCM:
     scm: url
-    url:  https://downloads.sourceforge.net/freetype/freetype-${PKG_VERSION}.tar.xz
+    url:  ${SOURCEFORGE_MIRROR}/freetype/freetype-${PKG_VERSION}.tar.xz
     digestSHA256: 86a854d8905b19698bbc8f23b860bc104246ce4854dcea8e3b0fb21284f75784
     stripComponents: 1
 

--- a/recipes/libs/fribidi.yaml
+++ b/recipes/libs/fribidi.yaml
@@ -5,7 +5,7 @@ metaEnvironment:
 
 checkoutSCM:
     scm: url
-    url: https://github.com/fribidi/fribidi/releases/download/v${PKG_VERSION}/fribidi-${PKG_VERSION}.tar.xz
+    url: ${GITHUB_MIRROR}/fribidi/fribidi/releases/download/v${PKG_VERSION}/fribidi-${PKG_VERSION}.tar.xz
     digestSHA256: 7f1c687c7831499bcacae5e8675945a39bacbad16ecaa945e9454a32df653c01
     stripComponents: 1
 

--- a/recipes/libs/harfbuzz.yaml
+++ b/recipes/libs/harfbuzz.yaml
@@ -14,7 +14,7 @@ depends:
 
 checkoutSCM:
     scm: url
-    url:  https://github.com/harfbuzz/harfbuzz/releases/download/${PKG_VERSION}/harfbuzz-${PKG_VERSION}.tar.xz
+    url:  ${GITHUB_MIRROR}/harfbuzz/harfbuzz/releases/download/${PKG_VERSION}/harfbuzz-${PKG_VERSION}.tar.xz
     digestSHA256: 6ad11d653347bd25d8317589df4e431a2de372c0cf9be3543368e07ec23bb8e7
     stripComponents: 1
 

--- a/recipes/libs/jsoncpp.yaml
+++ b/recipes/libs/jsoncpp.yaml
@@ -5,7 +5,7 @@ metaEnvironment:
 
 checkoutSCM:
     scm: url
-    url: https://github.com/open-source-parsers/jsoncpp/archive/1.9.3.tar.gz
+    url: ${GITHUB_MIRROR}/open-source-parsers/jsoncpp/archive/${PKG_VERSION}.tar.gz
     digestSHA256: 8593c1d69e703563d94d8c12244e2e18893eeb9a8a9f8aa3d09a327aa45c8f7d
     stripComponents: 1
 

--- a/recipes/libs/libcap.yaml
+++ b/recipes/libs/libcap.yaml
@@ -5,7 +5,7 @@ metaEnvironment:
 
 checkoutSCM:
     scm: url
-    url: https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-${PKG_VERSION}.tar.gz
+    url: ${KERNEL_MIRROR}/linux/libs/security/linux-privs/libcap2/libcap-${PKG_VERSION}.tar.gz
     digestSHA1: "0d6e242d70e80c243a7abeb787e007835b3f0d3d"
     extract: False
 

--- a/recipes/libs/libffi.yaml
+++ b/recipes/libs/libffi.yaml
@@ -5,7 +5,7 @@ metaEnvironment:
 
 checkoutSCM:
    scm: url
-   url: ftp://sourceware.org/pub/libffi/libffi-${PKG_VERSION}.tar.gz
+   url: ${SOURCEWARE_MIRROR}/libffi/libffi-${PKG_VERSION}.tar.gz
    digestSHA1: "280c265b789e041c02e5c97815793dfc283fb1e6"
    stripComponents: 1
 

--- a/recipes/libs/libpng.yaml
+++ b/recipes/libs/libpng.yaml
@@ -12,7 +12,7 @@ depends:
 
 checkoutSCM:
     scm: url
-    url: https://downloads.sourceforge.net/libpng/libpng-${PKG_VERSION}.tar.xz
+    url: ${SOURCEFORGE_MIRROR}/libpng/libpng-${PKG_VERSION}.tar.xz
     digestSHA1: 3ab93fabbf4c27e1c4724371df408d9a1bd3f656
     stripComponents: 1
 

--- a/recipes/libs/libuv.yaml
+++ b/recipes/libs/libuv.yaml
@@ -5,7 +5,7 @@ metaEnvironment:
 
 checkoutSCM:
     scm: url
-    url: https://github.com/libuv/libuv/archive/v${PKG_VERSION}.tar.gz
+    url: ${GITHUB_MIRROR}/libuv/libuv/archive/v${PKG_VERSION}.tar.gz
     digestSHA256: 2cd9a757fe6c512440933e2bdcab21143d4aa6249b2541399908ce038b756c9d
     stripComponents: 1
 

--- a/recipes/libs/newlib.yaml
+++ b/recipes/libs/newlib.yaml
@@ -10,7 +10,7 @@ metaEnvironment:
 
 checkoutSCM:
     scm: url
-    url: ftp://sourceware.org/pub/newlib/newlib-${PKG_VERSION}.tar.gz
+    url: ${SOURCEWARE_MIRROR}/newlib/newlib-${PKG_VERSION}.tar.gz
     digestSHA1: "6c0e467345ca6832eff6add85124c6e81e11d174"
     stripComponents: 1
 

--- a/recipes/libs/rhash.yaml
+++ b/recipes/libs/rhash.yaml
@@ -5,7 +5,7 @@ metaEnvironment:
 
 checkoutSCM:
     scm: url
-    url: https://sourceforge.net/projects/rhash/files/rhash/${PKG_VERSION}/rhash-${PKG_VERSION}-src.tar.gz
+    url: ${SOURCEFORGE_MIRROR}/rhash/rhash-${PKG_VERSION}-src.tar.gz
     digestSHA256: 98e0688acae29e68c298ffbcdbb0f838864105f9b2bd8857980664435b1f1f2e
     extract: false
 

--- a/recipes/libs/zlib.yaml
+++ b/recipes/libs/zlib.yaml
@@ -5,7 +5,7 @@ metaEnvironment:
 
 checkoutSCM:
    scm: url
-   url: http://downloads.sourceforge.net/project/libpng/zlib/1.2.8/zlib-${PKG_VERSION}.tar.gz
+   url: ${SOURCEFORGE_MIRROR}/libpng/zlib-${PKG_VERSION}.tar.gz
    digestSHA1: "a4d316c404ff54ca545ea71a27af7dbc29817088"
    extract: False
 

--- a/recipes/net/iperf.yaml
+++ b/recipes/net/iperf.yaml
@@ -9,7 +9,7 @@ depends:
 
 checkoutSCM:
     scm: url
-    url: "http://downloads.sourceforge.net/project/iperf2/iperf-${PKG_VERSION}.tar.gz"
+    url: ${SOURCEFORGE_MIRROR}/iperf2/iperf-${PKG_VERSION}.tar.gz
     digestSHA256: c88adec966096a81136dda91b4bd19c27aae06df4d45a7f547a8e50d723778ad
     stripComponents: 1
 

--- a/recipes/net/make-ca.yaml
+++ b/recipes/net/make-ca.yaml
@@ -1,7 +1,7 @@
 checkoutSCM:
     -
         scm: url
-        url: https://github.com/djlucas/make-ca/archive/v0.6.tar.gz
+        url: ${GITHUB_MIRROR}/djlucas/make-ca/archive/v0.6.tar.gz
         digestSHA1: 5f909366eca66c6c2caa8e44ca531d198b18a69d
         dir: make-ca
         stripComponents: 1

--- a/recipes/python/python3-setuptools.yaml
+++ b/recipes/python/python3-setuptools.yaml
@@ -3,7 +3,7 @@ metaEnvironment:
 
 checkoutSCM:
     scm: url
-    url: https://github.com/pypa/setuptools/archive/v${PKG_VERSION}.tar.gz
+    url: ${GITHUB_MIRROR}/pypa/setuptools/archive/v${PKG_VERSION}.tar.gz
     digestSHA256: d8203b2425014dd7b15b95c69a41454a98c90e5383c6a23d518f61c2e3e86bfd
     extract: False
 

--- a/recipes/utils/bzip2.yaml
+++ b/recipes/utils/bzip2.yaml
@@ -5,7 +5,7 @@ metaEnvironment:
 
 checkoutSCM:
     scm: url
-    url: https://sourceware.org/pub/bzip2/bzip2-${PKG_VERSION}.tar.gz
+    url: ${SOURCEWARE_MIRROR}/bzip2/bzip2-${PKG_VERSION}.tar.gz
     digestSHA1: "bf7badf7e248e0ecf465d33c2f5aeec774209227"
     extract: False
 

--- a/recipes/utils/e2fsprogs.yaml
+++ b/recipes/utils/e2fsprogs.yaml
@@ -5,7 +5,7 @@ metaEnvironment:
 
 checkoutSCM:
     scm: url
-    url: https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v${PKG_VERSION}/e2fsprogs-${PKG_VERSION}.tar.xz
+    url: ${KERNEL_MIRROR}/linux/kernel/people/tytso/e2fsprogs/v${PKG_VERSION}/e2fsprogs-${PKG_VERSION}.tar.xz
     digestSHA256: "65faf6b590ca1da97440d6446bd11de9e0914b42553740ba5d9d2a796fa0dc02"
     stripComponents: 1
 

--- a/recipes/utils/unzip.yaml
+++ b/recipes/utils/unzip.yaml
@@ -5,7 +5,7 @@ metaEnvironment:
 
 checkoutSCM:
     scm: url
-    url: https://sourceforge.net/projects/infozip/files/UnZip%206.x%20%28latest%29/UnZip%206.0/unzip${PKG_VERSION}.tar.gz
+    url: ${SOURCEFORGE_MIRROR}/infozip/unzip${PKG_VERSION}.tar.gz
     digestSHA1: "abf7de8a4018a983590ed6f5cbd990d4740f8a22"
     extract: False
 


### PR DESCRIPTION
with that it is possible to override the mirror variables in a upstream default.yaml.
we use this to mirror the archives on local servers.