### PR TITLE
utils/xz-utils: switch url directly to sourceforge

### DIFF
--- a/recipes/utils/xz-utils.yaml
+++ b/recipes/utils/xz-utils.yaml
@@ -5,7 +5,7 @@ metaEnvironment:
 
 checkoutSCM:
     scm: url
-    url: http://tukaani.org/xz/xz-${PKG_VERSION}.tar.xz
+    url: ${SOURCEFORGE_MIRROR}/lzmautils/xz-${PKG_VERSION}.tar.xz
     digestSHA1: "72c567d3263345844191a7e618779b179d1f49e0"
     stripComponents: 1
 


### PR DESCRIPTION
the old one was just a forwarded url to sourceforge. now we can mirror that file. for some reasons sourceforge does block us, or we them.