### PR TITLE
libs[/compat]/isl: switch mirror to sourceforge

### DIFF
--- a/recipes/libs/compat/isl.yaml
+++ b/recipes/libs/compat/isl.yaml
@@ -15,7 +15,7 @@ depends:
 
 checkoutSCM:
     scm: url
-    url: http://isl.gforge.inria.fr/isl-${PKG_VERSION}.tar.xz
+    url: ${SOURCEFORGE_MIRROR}/libisl/isl-${PKG_VERSION}.tar.xz
     digestSHA256: "45292f30b3cb8b9c03009804024df72a79e9b5ab89e41c94752d6ea58a1e4b02"
     stripComponents: 1
 

--- a/recipes/libs/isl.yaml
+++ b/recipes/libs/isl.yaml
@@ -17,7 +17,7 @@ depends:
 
 checkoutSCM:
     scm: url
-    url: http://isl.gforge.inria.fr/isl-${PKG_VERSION}.tar.xz
+    url: ${SOURCEFORGE_MIRROR}/libisl/isl-${PKG_VERSION}.tar.xz
     digestSHA256: "777058852a3db9500954361e294881214f6ecd4b594c00da5eee974cd6a54960"
     stripComponents: 1
 


### PR DESCRIPTION
reason: isl.gforge.inria.fr is down

.FIXES #97