### PR TITLE
classes/sandbox-toolchain: fixed issue added by #96

### DIFF
--- a/classes/sandbox-toolchain.yaml
+++ b/classes/sandbox-toolchain.yaml
@@ -28,7 +28,7 @@ fingerprintScript: |
     fi
 
 packageVars: [AUTOCONF_BUILD, SANDBOX_AUTOCONF_BUILD]
-packageSetup: |
+packageScript: |
     # Create a wrapper scripts that prefer the right executable in /toolchain
     # and (if we are outside of a sandbox) fall back to globally installed
     # versions.


### PR DESCRIPTION
changing from packageScript to packageSetup here isn't correct and breaks the sandbox