### PR TITLE
libs/glib: Package libraries alongside tools

### DIFF
--- a/recipes/libs/glib.yaml
+++ b/recipes/libs/glib.yaml
@@ -38,6 +38,8 @@ multiPackage:
         packageScript: mesonPackageLib
         provideDeps: [ "*-tgt" ]
     tools:
-        packageScript: mesonPackageBin
+        packageScript: mesonPackageTgt
         provideTools:
-            glib: usr/bin
+            glib:
+                path: usr/bin
+                libs: [ "usr/lib" ]


### PR DESCRIPTION
At least some of the glib tools such as the glib-resource-compiler need libgio.so in some form or another.

I'm still a bit unsure about the usage of `mesonPackageTgt` here, though: IMHO tools needing shared objects of their own projects shouldn't be *that* rare, so `mesonPackageBin` might actually handle that?!