### PR TITLE
devel/doxygen: moved python3 to buildToolsWeak

### DIFF
--- a/recipes/devel/doxygen.yaml
+++ b/recipes/devel/doxygen.yaml
@@ -9,7 +9,8 @@ checkoutSCM:
     digestSHA256: 67aeae1be4e1565519898f46f1f7092f1973cce8a767e93101ee0111717091d1
     stripComponents: 1
 
-buildTools: [flex, bison, dot, python3]
+buildTools: [flex, bison, dot]
+buildToolsWeak: [python3]
 buildScript: |
     cmakeBuild "$1"
 


### PR DESCRIPTION
just FindPythonInterp in CMake is used