### PR TITLE
classes/cmake: Set CMAKE_SYSTEM_PROCESSOR

### DIFF
--- a/classes/cmake.yaml
+++ b/classes/cmake.yaml
@@ -46,10 +46,33 @@ buildSetup: |
                 CMAKE_SYSTEM_NAME=Generic
                 ;;
         esac
+
+        CMAKE_SYSTEM_PROCESSOR=
+        if [ x"${AUTOCONF_HOST##*-}" == xwin32 ] ; then
+            case "$AUTOCONF_HOST" in
+                x86_64-*)
+                    CMAKE_SYSTEM_PROCESSOR=AMD64
+                    ;;
+                x86-*)
+                    CMAKE_SYSTEM_PROCESSOR=X86
+                    ;;
+                aarch64-*)
+                    CMAKE_SYSTEM_PROCESSOR=ARM64
+                    ;;
+                *)
+                    # Fall back to the raw processor prefix
+                    CMAKE_SYSTEM_PROCESSOR=${AUTOCONF_HOST%%-*}
+                    ;;
+            esac
+        else
+            CMAKE_SYSTEM_PROCESSOR=${AUTOCONF_HOST%%-*}
+        fi
+
         cat >toolchain.cmake <<EOF
     set(CMAKE_SYSTEM_NAME ${CMAKE_SYSTEM_NAME})
     set(CMAKE_C_COMPILER ${CC})
     set(CMAKE_CXX_COMPILER ${CXX})
+    set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_SYSTEM_PROCESSOR})
     set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
     set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
     set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)


### PR DESCRIPTION
Some CMake scripts access this variable unconditionally, such as
libjpeg-turbo's. Looking at the official docs [1] they seem to be right
in the assumption that CMAKE_SYSTEM_PROCESSOR will always be set.

[1] https://cmake.org/cmake/help/latest/variable/CMAKE_SYSTEM_PROCESSOR.html