### PR TITLE
classes/cmake: added sysroot to cmake_find_root_path

### DIFF
--- a/classes/cmake.yaml
+++ b/classes/cmake.yaml
@@ -12,6 +12,14 @@ buildSetup: |
         CMAKE_FIND_ROOT_PATH+="${CMAKE_FIND_ROOT_PATH:+;}$i"
     done
 
+    # It is necessary to add the sysroot path of gcc/g++ if available too
+    # because our host-compat-toolchain has a non-standard sysroot
+    # even though it's a native compiler
+    if [[ "$CC" == "gcc" ]] ; then
+        SYSROOT="$($CC -print-sysroot)"
+    fi
+    [ -z "${SYSROOT:+true}" ] || CMAKE_FIND_ROOT_PATH+="${CMAKE_FIND_ROOT_PATH:+;}${SYSROOT}"
+
     # This looks odd but it prevents MSYS from converting /usr to C:\msys64\usr
     # (or wherever MSYS was installed). See
     # http://mingw.org/wiki/Posix_path_conversion


### PR DESCRIPTION
It is necessary to add the sysroot path of gcc/g++ if available too
because our host-compat-toolchain has a non-standard sysroot
even though it's a native compiler

.FIXES #112