### PR TITLE
devel/automake: bump to 1.16.5

### DIFF
--- a/recipes/devel/automake.yaml
+++ b/recipes/devel/automake.yaml
@@ -1,7 +1,7 @@
 inherit: [autotools-noarch, patch]
 
 metaEnvironment:
-    PKG_VERSION: "1.15.1"
+    PKG_VERSION: "1.16.5"
 
 depends:
     - devel::autoconf
@@ -9,7 +9,7 @@ depends:
 checkoutSCM:
     scm: url
     url: ${GNU_MIRROR}/automake/automake-${PKG_VERSION}.tar.xz
-    digestSHA1: "45632d466c16ecf18d9c18dc4be883cde59acb59"
+    digestSHA1: "32fb36e73568271ff506b60c55a6170b67681375"
     stripComponents: 1
 
 checkoutDeterministic: True

--- a/recipes/devel/automake/0001-relocatable-automake.patch
+++ b/recipes/devel/automake/0001-relocatable-automake.patch
@@ -5,25 +5,25 @@ installed together with the autoconf package.
 
 Signed-off-by: Jan Klötzke <jan@kloetzke.net>
 
-diff -Nurp automake-1.15.1/bin/aclocal.in automake-1.15.1-patched/bin/aclocal.in
---- automake-1.15.1/bin/aclocal.in	2017-06-17 03:28:31.000000000 +0200
-+++ automake-1.15.1-patched/bin/aclocal.in	2020-06-12 18:12:47.277468706 +0200
-@@ -27,7 +27,9 @@ eval 'case $# in 0) exec @PERL@ -S "$0";
+diff -Nurp orig/bin/aclocal.in workspace/bin/aclocal.in
+--- orig/bin/aclocal.in	2021-07-12 04:41:13.000000000 +0200
++++ workspace/bin/aclocal.in	2022-03-07 17:25:04.880632399 +0100
+@@ -25,7 +25,9 @@ use warnings FATAL => 'all';
  
  BEGIN
  {
--  @Aclocal::perl_libdirs = ('@datadir@/@PACKAGE@-@APIVERSION@')
+-  unshift (@INC, '@datadir@/@PACKAGE@-@APIVERSION@')
 +  use File::Basename;
 +  use File::Spec;
-+  @Aclocal::perl_libdirs = ( File::Spec->catdir(File::Basename::dirname(File::Spec->rel2abs($0)), '..', 'share', '@PACKAGE@-@APIVERSION@') )
-     unless @Aclocal::perl_libdirs;
-   unshift @INC, @Aclocal::perl_libdirs;
++  unshift (@INC, File::Spec->catdir(File::Basename::dirname(File::Spec->rel2abs($0)), '..', 'share', '@PACKAGE@-@APIVERSION@'))
+     unless $ENV{AUTOMAKE_UNINSTALLED};
  }
-@@ -69,8 +71,9 @@ $perl_threads = 0;
+ 
+@@ -65,8 +67,9 @@ $perl_threads = 0;
  # ACLOCAL_PATH environment variable, and reset with the '--system-acdir'
  # option.
  my @user_includes = ();
--my @automake_includes = ("@datadir@/aclocal-$APIVERSION");
+-my @automake_includes = ('@datadir@/aclocal-' . $APIVERSION);
 -my @system_includes = ('@datadir@/aclocal');
 +my $prefix = File::Basename::dirname(File::Spec->rel2abs($0)) . '/..';
 +my @automake_includes = ("$prefix/share/aclocal-$APIVERSION");
@@ -31,32 +31,32 @@ diff -Nurp automake-1.15.1/bin/aclocal.in automake-1.15.1-patched/bin/aclocal.in
  
  # Whether we should copy M4 file in $user_includes[0].
  my $install = 0;
-diff -Nurp automake-1.15.1/bin/automake.in automake-1.15.1-patched/bin/automake.in
---- automake-1.15.1/bin/automake.in	2017-06-17 03:28:31.000000000 +0200
-+++ automake-1.15.1-patched/bin/automake.in	2020-06-12 18:12:47.285468820 +0200
-@@ -31,7 +31,9 @@ use strict;
+Binary files orig/bin/.aclocal.in.swp and workspace/bin/.aclocal.in.swp differ
+diff -Nurp orig/bin/automake.in workspace/bin/automake.in
+--- orig/bin/automake.in	2021-09-20 02:53:14.000000000 +0200
++++ workspace/bin/automake.in	2022-03-07 17:26:55.183158614 +0100
+@@ -28,7 +28,9 @@ use warnings FATAL => 'all';
  
  BEGIN
  {
--  @Automake::perl_libdirs = ('@datadir@/@PACKAGE@-@APIVERSION@')
+-  unshift (@INC, '@datadir@/@PACKAGE@-@APIVERSION@')
 +  use File::Basename;
 +  use File::Spec;
-+  @Automake::perl_libdirs = ( File::Spec->catdir(File::Basename::dirname(File::Spec->rel2abs($0)), '..', 'share', '@PACKAGE@-@APIVERSION@') )
-     unless @Automake::perl_libdirs;
-   unshift @INC, @Automake::perl_libdirs;
++  unshift (@INC, File::Spec->catdir(File::Basename::dirname(File::Spec->rel2abs($0)), '..', 'share', '@PACKAGE@-@APIVERSION@'))
+     unless $ENV{AUTOMAKE_UNINSTALLED};
  
-diff -Nurp automake-1.15.1/lib/Automake/Config.in automake-1.15.1-patched/lib/Automake/Config.in
---- automake-1.15.1/lib/Automake/Config.in	2017-06-16 22:46:16.000000000 +0200
-+++ automake-1.15.1-patched/lib/Automake/Config.in	2020-06-12 17:09:03.862271805 +0200
-@@ -32,7 +32,10 @@ our $PACKAGE = '@PACKAGE@';
+   # Override SHELL.  This is required on DJGPP so that system() uses
+diff -Nurp orig/lib/Automake/Config.in workspace/lib/Automake/Config.in
+--- orig/lib/Automake/Config.in	2021-07-12 04:41:13.000000000 +0200
++++ workspace/lib/Automake/Config.in	2022-03-07 17:29:56.448736062 +0100
+@@ -34,7 +34,9 @@ our $PACKAGE = '@PACKAGE@';
  our $PACKAGE_BUGREPORT = '@PACKAGE_BUGREPORT@';
  our $VERSION = '@VERSION@';
  our $RELEASE_YEAR = '@RELEASE_YEAR@';
--our $libdir = '@datadir@/@PACKAGE@-@APIVERSION@';
-+
+-our $libdir = $ENV{"AUTOMAKE_LIBDIR"} || '@datadir@/@PACKAGE@-@APIVERSION@';
 +use File::Basename;
 +use File::Spec;
-+our $libdir = File::Basename::dirname(__FILE__) . '/..';
++our $libdir = $ENV{"AUTOMAKE_LIBDIR"} || File::Basename::dirname(__FILE__) . '/..';
  
  our $perl_threads = 0;
  # We need at least this version for CLONE support.


### PR DESCRIPTION
Fixes indeterministic automake outputs that were generated in case of
conditional rules. See #116.