### PR TITLE
classes/install: fixed typo, replaced stripFile by stripBinary

### DIFF
--- a/classes/install.yaml
+++ b/classes/install.yaml
@@ -71,9 +71,9 @@ packageSetup: |
         fi
     }
 
-    installStripFile()
+    installStripBinary()
     {
-        stripFile "$1"
+        stripBinary "$1"
     }
 
     installStripAll()


### PR DESCRIPTION
typo? stripFile doesn't exists.