### PR TITLE
WIP: devel/compat/gcc: use c++11 standard

### DIFF
--- a/recipes/devel/compat/gcc.yaml
+++ b/recipes/devel/compat/gcc.yaml
@@ -32,7 +32,7 @@ checkoutScript: |
         $<<gcc/buildroot-libtool-v2.2.patch>>
 
 buildTools: [host-toolchain]
-buildVars: [AUTOCONF_BUILD, AUTOCONF_HOST, AUTOCONF_TARGET,
+buildVars: [AUTOCONF_BUILD, AUTOCONF_HOST, AUTOCONF_TARGET, CXXFLAGS,
             GCC_TARGET_ARCH, GCC_TARGET_FLOAT_ABI, GCC_TARGET_FPU]
 buildScript: |
     GCC_SRC=$1
@@ -54,6 +54,7 @@ buildScript: |
 
     [ -z "${CPPFLAGS:+true}" ] || export CPPFLAGS
     [ -z "${LDFLAGS:+true}" ] || export LDFLAGS
+    export CXXFLAGS="-std=c++11${CXXFLAGS:+ $CXXFLAGS}"
 
     buildGcc()
     {


### PR DESCRIPTION
necessary for newer gcc versions, like gcc 11.2.0
to prevent the compiler error:
`use of an operand of type 'bool' in 'operator++' is forbidden in C++17`