### PR TITLE
devel/compat/gcc: use c++11 standard

### DIFF
--- a/recipes/devel/host-compat-toolchain.yaml
+++ b/recipes/devel/host-compat-toolchain.yaml
@@ -8,6 +8,10 @@ shared: True
 environment:
     AUTOCONF_TARGET: "$(gen-autoconf,bob_compat)"
 
+privateEnvironment:
+    # compat gcc 5.4 compilation will fail with c++17
+    CXXFLAGS: "${CXXFLAGS:+$CXXFLAGS }-std=c++11"
+
 depends:
     # The following tools are needed by the cross-toolchain build process.
     # Build them explicitly here to keep the basement::rootrecipe class


### PR DESCRIPTION
necessary for newer gcc versions, like gcc 11.2.0
to prevent the compiler error:
`use of an operand of type 'bool' in 'operator++' is forbidden in C++17`

.FIXES #123