### PR TITLE
devel[/compat]/gcc: Install sequentially

### DIFF
--- a/recipes/devel/compat/gcc.yaml
+++ b/recipes/devel/compat/gcc.yaml
@@ -81,7 +81,7 @@ buildScript: |
             touch .configure.stamp
         fi
         makeParallel
-        make install DESTDIR=${PWD}/../install
+        makeSequential install DESTDIR=${PWD}/../install
         popd
     }
 

--- a/recipes/devel/gcc.yaml
+++ b/recipes/devel/gcc.yaml
@@ -67,7 +67,7 @@ buildScript: |
             touch .configure.stamp
         fi
         makeParallel
-        make install DESTDIR=${PWD}/../install
+        makeSequential install DESTDIR=${PWD}/../install
         popd
     }
 


### PR DESCRIPTION
Installing in parallel can lead to files already existing, causing
errors like the following:

```
/usr/bin/install: cannot create regular file '/bob/d9a8abbafac9128d662477c77d7585af393f3b55/workspace/build/../install/usr/lib/gcc/x86_64-cross-linux-gnu/9.2.0/include/ssp/stdio.h': File exists
```