### PR TITLE
libs/freetype: Add host toolchain to build tools

### DIFF
--- a/recipes/libs/freetype.yaml
+++ b/recipes/libs/freetype.yaml
@@ -16,6 +16,7 @@ checkoutSCM:
     digestSHA256: 86a854d8905b19698bbc8f23b860bc104246ce4854dcea8e3b0fb21284f75784
     stripComponents: 1
 
+buildTools: [host-toolchain]
 buildScript: |
     autotoolsBuild $1
 


### PR DESCRIPTION
Unrelated changes (#128) revealed that this change is necessary. It must have been shadowed somehow with the old toolchain...

The error message was

```
[ 630] BUILD     libs::freetype-tgt - work/libs/freetype-tgt/x86_64-cross-linux-gnu/build/6/workspace
[ 630] |libs::freetype-tgt| cp: cannot stat '/bob/7e1a2c0b5bdf98f3a128373a90eaa634a9aa66fa/workspace/docs/markdown': No such file or directory
[ 630] |libs::freetype-tgt| configure: WARNING: using cross tools not prefixed with host triplet
[ 630] |libs::freetype-tgt| configure: error: cannot find native C compiler
[ 630] |libs::freetype-tgt| make: *** [/bob/7e1a2c0b5bdf98f3a128373a90eaa634a9aa66fa/workspace/builds/unix/detect.mk:89: setup] Error 1
[ 630] |libs::freetype-tgt| Step failed with return status 2; Command: $1/configure ${AUTOCONF_BUILD:+--build=${AUTOCONF_BUILD}} ${AUTOCONF_HOST:+--host=${AUTOCONF_HOST}} ${AUTOCONF_TARGET:+--target=${AUTOCONF_TARGET}} --prefix="/usr" --sysconfdir="/etc" --localstatedir="/var" --libdir=/usr/lib ${SHARED_STATIC:+"${SHARED_STATIC[@]}"} "${@:2}"
[ 630] |libs::freetype-tgt| Call stack (most recent call first)
[ 630] |libs::freetype-tgt|     #0: Class  autotools, layer basement, line 58, in autotoolsBuild
[ 630] |libs::freetype-tgt|     #1: Recipe libs::freetype#1, layer basement, line 1, in main
```