### PR TITLE
devel/git: Provide Git as a tool

### DIFF
--- a/recipes/devel/git.yaml
+++ b/recipes/devel/git.yaml
@@ -1,7 +1,7 @@
 inherit: [make, install]
 
 metaEnvironment:
-    PKG_VERSION: "2.24.0"
+    PKG_VERSION: "2.36.1"
 
 depends:
     - libs::zlib-dev
@@ -18,7 +18,7 @@ depends:
 checkoutSCM:
     scm: url
     url: ${KERNEL_MIRROR}/software/scm/git/git-${PKG_VERSION}.tar.xz
-    digestSHA1: "851537fc03f5a99419ef20e9b836de965c7928bd"
+    digestSHA256: "405d4a0ff6e818d1f12b3e92e1ac060f612adcb454f6299f70583058cb508370"
     extract: False
 
 buildTools: [target-toolchain, curl]

--- a/recipes/devel/git.yaml
+++ b/recipes/devel/git.yaml
@@ -1,4 +1,4 @@
-inherit: [make, install, pkg-config]
+inherit: [cpackage, install, make, pkg-config]
 
 metaEnvironment:
     PKG_VERSION: "2.36.1"
@@ -22,12 +22,8 @@ checkoutSCM:
     extract: False
 
 buildTools: [target-toolchain, curl]
-buildVars: [PKG_VERSION, AUTOCONF_HOST,
-    CPPFLAGS, CFLAGS, LDFLAGS]
+buildVars: [AUTOCONF_HOST, PKG_VERSION]
 buildScript: |
-    export CFLAGS="-I${BOB_DEP_PATHS[libs::zlib-dev]}/usr/include -I${BOB_DEP_PATHS[libs::openssl-dev]}/usr/include"
-    export LDFLAGS="-L${BOB_DEP_PATHS[libs::zlib-dev]}/usr/lib -L${BOB_DEP_PATHS[libs::openssl-dev]}/usr/lib -Wl,-rpath-link=${BOB_DEP_PATHS[libs::zlib-dev]}/usr/lib -Wl,-rpath-link=${BOB_DEP_PATHS[libs::openssl-dev]}/usr/lib"
-
     mkdir -p install
     tar -xf $1/git-${PKG_VERSION}.tar.xz
 

--- a/recipes/devel/git.yaml
+++ b/recipes/devel/git.yaml
@@ -1,4 +1,4 @@
-inherit: [make, install]
+inherit: [make, install, pkg-config]
 
 metaEnvironment:
     PKG_VERSION: "2.36.1"
@@ -37,7 +37,7 @@ buildScript: |
                 --with-curl=${BOB_DEP_PATHS[net::curl-dev]}/usr \
                 --without-python \
                 --without-expat
-    makeParallel
+    makeParallel LIB_4_CRYPTO="$(pkg-config --libs libssl libcrypto)"
     make DESTDIR=${PWD}/../install install
     popd
 

--- a/recipes/devel/git.yaml
+++ b/recipes/devel/git.yaml
@@ -41,7 +41,16 @@ buildScript: |
     make DESTDIR=${PWD}/../install install
     popd
 
-packageScript: |
-    installPackageTgt "$1/install/"
+multiPackage:
+    "":
+        packageScript: |
+            installPackageTgt "$1/install/"
 
-provideDeps: [ "*-tgt" ]
+        provideDeps: [ "*-tgt" ]
+
+    tools:
+        packageScript: |
+            installPackageBin "$1/install/"
+
+        provideTools:
+            git: "usr/bin"


### PR DESCRIPTION
First things first: The final goal is to have Git as a tool.

With that being said, compiling for the sandbox fails because the static version of the `crypto` lib needs `dl`, as stated in its `pkg-config` file (as `Libs.private`). As Git's `Makefile` doesn't use `pkg-config` but rather hard-coded compiler flags, the needed `-ldl` switch is missing when linking statically. With the changes presented here, Git can be build as a tool and works without any obvious problems. Of course, this change set cannot be the final solution.

My question is: where would be an appropriate place to put that `-ldl`? Patching the `Makefile`? But what about the non-static build? Or patching the `Makefile` conditionally?