### PR TITLE
classes/{autotools(-*)?,meson}: Remove install dir

### DIFF
--- a/classes/autotools-noarch.yaml
+++ b/classes/autotools-noarch.yaml
@@ -37,8 +37,10 @@ buildSetup: |
         done
         shift $(( OPTIND -1 ))
 
+        rm -rf install
         mkdir -p build install
         pushd build
+
         if [[ $1/configure -nt .configure.stamp ]] ; then
             $1/configure \
                 --prefix="/usr" \

--- a/classes/autotools.yaml
+++ b/classes/autotools.yaml
@@ -55,8 +55,10 @@ buildSetup: |
         done
         shift $(( OPTIND -1 ))
 
+        rm -rf install
         mkdir -p build install
         pushd build
+
         if [[ $1/configure -nt .configure.stamp ]] ; then
             $1/configure \
                 ${AUTOCONF_BUILD:+--build=${AUTOCONF_BUILD}} \

--- a/classes/meson.yaml
+++ b/classes/meson.yaml
@@ -90,8 +90,10 @@ buildSetup: |
     # $1 : source path
     mesonBuild()
     {
+        rm -rf install
         mkdir -p build install
         pushd build
+
         if [[ ! -e .meson-done ]] ; then
             declare -a MESON_OPTIONS=( "$1" "$PWD")
             if [[ -e $BOB_CWD/cross_file.txt ]] ; then


### PR DESCRIPTION
Analogous to what the CMake class already does, the install directory
should be removed before each new compilation to avoid conflicts with
old files still lingering around.

I've tested these changes by building our current project. From what I
can tell, the output is the same.

Fixes #138