### PR TITLE
Bugfix/msys2gitstuff

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.git*   eol=lf export-ignore
+*       eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,2 @@
-/dev
-/work
 .bob-*
-user.yaml
 __pycache__/

--- a/tests/cross-platform/.gitignore
+++ b/tests/cross-platform/.gitignore
@@ -1,2 +1,4 @@
-/dev
+/dev*
 /work
+/graph
+/projects

--- a/tests/linux/.gitignore
+++ b/tests/linux/.gitignore
@@ -1,2 +1,4 @@
-/dev
+/dev*
 /work
+/graph
+/projects

--- a/tests/linux/recipes/buildall.yaml
+++ b/tests/linux/recipes/buildall.yaml
@@ -1,5 +1,8 @@
 inherit: [ "basement::rootrecipe" ]
 
+root: !expr |
+  "${BOB_HOST_PLATFORM}" == "linux"
+
 depends:
     - devel::cross-toolchain-x86_64-linux-gnu
     - devel::cross-toolchain-arm-linux-gnueabihf

--- a/tests/linux/recipes/meson/greeter.yaml
+++ b/tests/linux/recipes/meson/greeter.yaml
@@ -1,5 +1,8 @@
 inherit: [ "basement::rootrecipe", meson ]
 
+root: !expr |
+  "${BOB_HOST_PLATFORM}" == "linux"
+
 checkoutSCM:
     scm: import
     url: src/greeter/


### PR DESCRIPTION
the git-stuff took us some days of searching for mismatching artifacts. the problem was, that a developer used the native git binary with autocrlf enabled. so the patches hat crlf endings, and the patched files differed to the other ones.