### PR TITLE
devel/fakeroot: update to v1.29

### DIFF
--- a/recipes/devel/fakeroot.yaml
+++ b/recipes/devel/fakeroot.yaml
@@ -1,7 +1,7 @@
 inherit: [autotools]
 
 metaEnvironment:
-    PKG_VERSION: "1.28"
+    PKG_VERSION: "1.29"
 
 depends:
     - libs::libcap-dev
@@ -13,7 +13,7 @@ depends:
 checkoutSCM:
     scm: url
     url: http://ftp.debian.org/debian/pool/main/f/fakeroot/fakeroot_${PKG_VERSION}.orig.tar.gz
-    digestSHA1: "29da337af47ff44da39768875603dc644ee8b8a8"
+    digestSHA256: 8fbbafb780c9173e3ace4a04afbc1d900f337f3216883939f5c7db3431be7c20
     stripComponents: 1
 
 buildScript: |


### PR DESCRIPTION
v1.28 is deleted on the file server

.FIXES#155