### PR TITLE
multiarch: fix autoconf triplet for aarch64

### DIFF
--- a/plugins/multiarch.py
+++ b/plugins/multiarch.py
@@ -4,25 +4,28 @@ import platform
 
 # TODO: support more architectures; support musl/dietlibc
 
-# get host architecture
-def hostArch(args, **options):
+def normalizedHostMachine():
     m = platform.uname().machine
-    if m == "x86_64":
-        return m
-    elif m == "AMD64":
+    if m == "AMD64":
         return "x86_64"
     elif m.startswith("i"):
         return "i386"
-    elif m.startswith("aarch64"):
+    else:
+        return m
+
+# get host architecture
+def hostArch(args, **options):
+    m = normalizedHostMachine()
+    if m.startswith("aarch64"):
         return "arm64"
     elif m.startswith("arm"):
         return "arm"
     else:
-        raise ParseError("Unsupported host machine: " + m)
+        return m
 
 # get host autoconf triple
 def hostAutoconf(args, **options):
-    machine = hostArch(None)
+    machine = normalizedHostMachine()
     system = platform.uname().system
     if system == 'Linux':
         return machine + "-linux-gnu"


### PR DESCRIPTION
The $(host-arch) function returns what the Linux kernel expects for the ARCH environment variable. This is not compatible to the autoconf triplet. For example the "aarch64-linux-gnu" triplet corresponds to the "arm64" ARCH.

Fixes #162.