### PR TITLE
devel/patch: bump to 2.7.6

### DIFF
--- a/recipes/devel/patch.yaml
+++ b/recipes/devel/patch.yaml
@@ -1,12 +1,12 @@
 inherit: [autotools]
 
 metaEnvironment:
-    PKG_VERSION: "2.7.5"
+    PKG_VERSION: "2.7.6"
 
 checkoutSCM:
     scm: url
     url: ${GNU_MIRROR}/patch/patch-${PKG_VERSION}.tar.xz
-    digestSHA1: "8fd8f8f8ba640d871bce1bd33c7fd5e2ebe03a1e"
+    digestSHA1: "6f64fa75993bdb285ac4ed6eca6c9212725bff91"
     stripComponents: 1
 
 buildScript: |


### PR DESCRIPTION
This minor version upgrade has a crucial fix that newly created files have the correct mode as specified in the patch. Because 849b79a6932687079d5f9277f26177f7cf40eb81 introduced a patch in libs::glibc that creates an executable file, the basement repo actually ran into this bug.

Even more problematic, the latest patch version was released 5 years ago, so that basically all distros already ship the latest version. This has the effect that almost all basement artifact downloads fail. The reason is the distributed Jenkins build. The checkout of libs::glibc is done multiple times. Once without sandbox and then in the bootstrap-sandbox. Because of the old patch version in the bootstrap-sandbox the checkout got inconsistent.