### PR TITLE
python/python3: prevent using system stuff while cross-compiling

### DIFF
--- a/recipes/python/python3.yaml
+++ b/recipes/python/python3.yaml
@@ -61,6 +61,8 @@ multiPackage:
             export ac_cv_have_long_long_format=yes
             export ac_cv_prog_HAS_HG=/bin/false
             export ac_cv_working_tzset=yes
+            # force cross-compiling in setup.py
+            export _PYTHON_HOST_PLATFORM=linux
 
             autotoolsBuild $PWD/src \
                 --disable-bzip2 \
@@ -104,6 +106,8 @@ multiPackage:
            - libs::zlib-dev
 
         buildScript: |
+            # force cross-compiling in setup.py
+            export _PYTHON_HOST_PLATFORM=linux
             autotoolsBuild $PWD/src \
                 --disable-bzip2 \
                 --disable-codecs-cjk \


### PR DESCRIPTION

without this workaround the system uses include directories of the host
like /usr/include/x86_64-linux-gnu and /usr/local/include

this results in build errors. root cause is the configure script
generated by autoconf:

```
  elif test "x$build_alias" != "x$host_alias"; then
    cross_compiling=yes
```

but in our case, using the host-compat-toolchain, host and build alias
is the same. cross-compiling will be disabled and system pahts used.

hope that fix is fine enough for general usage inside of bob.