### PR TITLE
utils/file: use https instead of ftp file download

### DIFF
--- a/recipes/utils/file.yaml
+++ b/recipes/utils/file.yaml
@@ -5,7 +5,7 @@ metaEnvironment:
 
 checkoutSCM:
     scm: url
-    url: ftp://ftp.astron.com/pub/file/file-${PKG_VERSION}.tar.gz
+    url: https://www.astron.com/pub/file/file-${PKG_VERSION}.tar.gz
     digestSHA256: "8c8015e91ae0e8d0321d94c78239892ef9dbc70c4ade0008c0e95894abfb1991"
     stripComponents: 1
 


### PR DESCRIPTION
at least in our network, the ftp url is not available.