### PR TITLE
Update python::python3-setuptools

### DIFF
--- a/recipes/python/python3-setuptools.yaml
+++ b/recipes/python/python3-setuptools.yaml
@@ -1,10 +1,10 @@
 metaEnvironment:
-    PKG_VERSION: "44.1.1"
+    PKG_VERSION: "52.0.0"
 
 checkoutSCM:
     scm: url
     url: ${GITHUB_MIRROR}/pypa/setuptools/archive/v${PKG_VERSION}.tar.gz
-    digestSHA256: d8203b2425014dd7b15b95c69a41454a98c90e5383c6a23d518f61c2e3e86bfd
+    digestSHA256: ff0c74d1b905a224d647f99c6135eacbec2620219992186b81aa20012bc7f882
     extract: False
 
 buildTools: [python3]


### PR DESCRIPTION
To get a mildly recent setuptools-scm installed there needs to be a newer version of setuptools. So this updates setuptools to a version where the current build steps still work.