### PR TITLE
Add python::python3-dev with headers

### DIFF
--- a/recipes/python/python3.yaml
+++ b/recipes/python/python3.yaml
@@ -91,13 +91,19 @@ multiPackage:
             rsync -a "${BOB_DEP_PATHS[python::python3-pip]}/" install/
             rsync -a "${BOB_DEP_PATHS[python::python3-wheel]}/" install/
 
-        packageScript: |
-            autotoolsPackageTgt
-            ln -sf python3 usr/bin/python
+        multiPackage:
+            "":
+                provideDeps: [ "*-tgt" ]
+                provideTools:
+                    python3: usr/bin
 
-        provideDeps: [ "*-tgt" ]
-        provideTools:
-            python3: usr/bin
+                packageScript: |
+                    autotoolsPackageTgt
+                    ln -sf python3 usr/bin/python
+            dev:
+                packageScript: |
+                    autotoolsPackageDev
+
 
     minimal:
         depends:


### PR DESCRIPTION
Adds a separate package with /usr/include from the python3 build.