### PR TITLE
devel::git - Install using symlinks

### DIFF
--- a/recipes/devel/git.yaml
+++ b/recipes/devel/git.yaml
@@ -44,7 +44,7 @@ buildScript: |
                 --without-iconv \
                 ${EXTRA:+"${EXTRA[@]}"}
     makeParallel LIB_4_CRYPTO="$(pkg-config --libs libssl libcrypto)"
-    make DESTDIR=${PWD}/../install install
+    make DESTDIR=${PWD}/../install install NO_INSTALL_HARDLINKS=1
     popd
 
 multiPackage:


### PR DESCRIPTION
git by default uses hardlinks to provide multiple executables with the same binary. This however doesn't translate well when copying around the installed files during the packaging step as the hardlinks are not reestablished, but the files are now duplicated, which results in a git installation with a size of more than 300MB.

For these cases git build system has a make variable called NO_INSTALL_HARDLINKS which can be passed along during make install to use symlinks instead of hardlinks.