### PR TITLE
devel/flex: fix regression introduced in flex 2.6.3

### DIFF
--- a/recipes/devel/flex.yaml
+++ b/recipes/devel/flex.yaml
@@ -9,6 +9,10 @@ checkoutSCM:
     digestSHA256: 68b2742233e747c462f781462a2a1e299dc6207401dac8f0bbb316f48565c2aa
     stripComponents: 1
 
+checkoutDeterministic: True
+checkoutScript: |
+    patchApplySeries $<<flex/*>>
+
 buildTools: [bison]
 buildScript: |
     export M4=m4

--- a/recipes/devel/flex/0001-scanner-use-prefix-when-defining-yywrap-avoid-redefinition.patch
+++ b/recipes/devel/flex/0001-scanner-use-prefix-when-defining-yywrap-avoid-redefinition.patch
@@ -1,0 +1,27 @@
+From f5d87f1a26f4a5c3402497008ae10e9a1345d327 Mon Sep 17 00:00:00 2001
+From: Christos Zoulas <christos@zoulas.com>
+Date: Sun, 22 Jan 2017 18:20:44 +0100
+Subject: [PATCH] scanner: Use prefix when defining yywrap to avoid
+ redefinition.
+
+Fixes regression introduced in v2.6.3.
+---
+ src/main.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/main.c b/src/main.c
+index f70b1aa4a..83f66b04d 100644
+--- a/src/main.c
++++ b/src/main.c
+@@ -1586,9 +1586,9 @@ void readin (void)
+ 	if (!do_yywrap) {
+ 		if (!C_plus_plus) {
+ 			 if (reentrant)
+-				outn ("\n#define yywrap(yyscanner) (/*CONSTCOND*/1)");
++				out_str ("\n#define %swrap(yyscanner) (/*CONSTCOND*/1)\n", prefix);
+ 			 else
+-				outn ("\n#define yywrap() (/*CONSTCOND*/1)");
++				out_str ("\n#define %swrap() (/*CONSTCOND*/1)\n", prefix);
+ 		}
+ 		outn ("#define YY_SKIP_YYWRAP");
+ 	}


### PR DESCRIPTION
flex scanner: Use prefix when defining yywrap to avoid redefinition