### PR TITLE
devel/flex: version bump to 2.6.4

### DIFF
--- a/classes/basement/rootrecipe.yaml
+++ b/classes/basement/rootrecipe.yaml
@@ -35,6 +35,9 @@ depends:
         - name: devel::autotools
           use: [tools]
           forward: True
+        - name: devel::gettext
+          use: [tools]
+          forward: True
         - name: devel::bison
           use: [tools]
           forward: True

--- a/recipes/devel/bootstrap-sandbox.yaml
+++ b/recipes/devel/bootstrap-sandbox.yaml
@@ -59,7 +59,6 @@ depends:
     - devel::diffutils
     - devel::m4
     - devel::patch
-    - devel::gettext
     - net::make-ca
     - perl::perl
     - utils::bash

--- a/recipes/devel/bootstrap-sandbox.yaml
+++ b/recipes/devel/bootstrap-sandbox.yaml
@@ -21,6 +21,10 @@ depends:
         use: [tools]
         forward: True
     -
+        name: devel::gettext
+        use: [tools]
+        forward: True
+    -
         name: devel::pkg-config-tool
         use: [tools]
         forward: True

--- a/recipes/devel/flex.yaml
+++ b/recipes/devel/flex.yaml
@@ -1,15 +1,23 @@
-inherit: [autotools]
+inherit: [autotools, autoconf, patch]
 
 metaEnvironment:
-    PKG_VERSION: "2.6.3"
+    PKG_VERSION: "2.6.4"
 
 checkoutSCM:
     scm: url
     url: ${GITHUB_MIRROR}/westes/flex/releases/download/v${PKG_VERSION}/flex-${PKG_VERSION}.tar.gz
-    digestSHA256: 68b2742233e747c462f781462a2a1e299dc6207401dac8f0bbb316f48565c2aa
+    digestSHA256: e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995
     stripComponents: 1
 
-buildTools: [bison]
+checkoutDeterministic: True
+checkoutTools: [gettext]
+checkoutScript: |
+    patchApplySeries $<<flex/*.patch>>
+    autoconfReconfigure
+    # prevent Makefile from updating the file because it's older than "configure"
+    touch doc/stamp-vti
+
+buildTools: [bison, host-toolchain]
 buildScript: |
     export M4=m4
     autotoolsBuild $1 \

--- a/recipes/devel/flex/0001-flex-2.6.4-pie-reallocarray-fix.patch
+++ b/recipes/devel/flex/0001-flex-2.6.4-pie-reallocarray-fix.patch
@@ -1,0 +1,39 @@
+This patch fixes a flex-2.6.4 build failure on x86_64 and possibly other
+architectures where `size_t' is larger than `int'. The failure occurs as
+follows:
+
+A missing `reallocarray' prototype during compilation means that the
+compiler assumes an `int' return type. When compiling with `-pie' (standard
+for Fedora), addresses on the heap can be larger than `int' can store. Thus,
+pointers returned from `reallocarray' are truncated and any read/write to
+them leads to a SIGSEGV.
+
+From 24fd0551333e7eded87b64dd36062da3df2f6380 Mon Sep 17 00:00:00 2001
+From: Explorer09 <explorer09@gmail.com>
+Date: Mon, 4 Sep 2017 10:47:33 +0800
+Subject: [PATCH] build: AC_USE_SYSTEM_EXTENSIONS in configure.ac.
+
+This would, e.g. define _GNU_SOURCE in config.h, enabling the
+reallocarray() prototype in glibc 2.26+ on Linux systems with that
+version of glibc.
+
+Fixes #241.
+---
+ configure.ac | 2 ++
+ 1 file changed, 2 insertions(+)
+
+Index: b/configure.ac
+===================================================================
+--- a/configure.ac
++++ b/configure.ac
+@@ -25,8 +25,10 @@
+ # autoconf requirements and initialization
+ 
+ AC_INIT([the fast lexical analyser generator],[2.6.4],[flex-help@lists.sourceforge.net],[flex])
++AC_PREREQ([2.60])
+ AC_CONFIG_SRCDIR([src/scan.l])
+ AC_CONFIG_AUX_DIR([build-aux])
++AC_USE_SYSTEM_EXTENSIONS
+ LT_INIT
+ AM_INIT_AUTOMAKE([1.11.3 -Wno-portability foreign check-news std-options dist-lzip parallel-tests subdir-objects])
+ AC_CONFIG_HEADER([src/config.h])

--- a/recipes/devel/gettext.yaml
+++ b/recipes/devel/gettext.yaml
@@ -10,7 +10,8 @@ checkoutSCM:
     stripComponents: 1
 
 buildScript: |
-    autotoolsBuild $1
+    autotoolsBuild $1 \
+        --enable-relocatable
 
 packageScript: |
     autotoolsPackageTgt

--- a/recipes/devel/gettext.yaml
+++ b/recipes/devel/gettext.yaml
@@ -1,12 +1,12 @@
 inherit: [autotools]
 
 metaEnvironment:
-    PKG_VERSION: "0.19.7"
+    PKG_VERSION: "0.22.4"
 
 checkoutSCM:
     scm: url
-    url: ${GNU_MIRROR}/gettext/gettext-${PKG_VERSION}.tar.gz
-    digestSHA1: "d8fc932196cc78b83ca1b63c8687ec3d513b40b6"
+    url: ${GNU_MIRROR}/gettext/gettext-${PKG_VERSION}.tar.xz
+    digestSHA256: "29217f1816ee2e777fa9a01f9956a14139c0c23cc1b20368f06b2888e8a34116"
     stripComponents: 1
 
 buildScript: |

--- a/recipes/devel/git.yaml
+++ b/recipes/devel/git.yaml
@@ -21,7 +21,7 @@ checkoutSCM:
     digestSHA256: "405d4a0ff6e818d1f12b3e92e1ac060f612adcb454f6299f70583058cb508370"
     extract: False
 
-buildTools: [target-toolchain, curl, host-toolchain]
+buildTools: [target-toolchain, curl, host-toolchain, gettext]
 buildVars: [AUTOCONF_BUILD, AUTOCONF_HOST, PKG_VERSION]
 buildScript: |
 

--- a/recipes/devel/host-compat-toolchain.yaml
+++ b/recipes/devel/host-compat-toolchain.yaml
@@ -15,6 +15,12 @@ depends:
     - name: devel::make
       use: [tools]
       forward: True
+    - name: devel::autotools
+      use: [tools]
+      forward: True
+    - name: devel::gettext
+      use: [tools]
+      forward: True
     - name: devel::bison
       use: [tools]
       forward: True

--- a/recipes/devel/sandbox.yaml
+++ b/recipes/devel/sandbox.yaml
@@ -27,6 +27,10 @@ depends:
         use: [tools]
         forward: True
     -
+        name: devel::gettext
+        use: [tools]
+        forward: True
+    -
         name: devel::pkg-config-tool
         use: [tools]
         forward: True

--- a/recipes/devel/sandbox.yaml
+++ b/recipes/devel/sandbox.yaml
@@ -68,7 +68,6 @@ depends:
     - devel::m4
     - devel::patch
     - devel::texinfo
-    - devel::gettext
     - net::make-ca
     - perl::perl
     - utils::bash

--- a/tests/linux/recipes/buildall.yaml
+++ b/tests/linux/recipes/buildall.yaml
@@ -18,6 +18,7 @@ packageTools:
     - bison
     - cmake
     - flex
+    - gettext
     - make
     - meson
     - ninja


### PR DESCRIPTION
fix included, that prevents segmentation fault while using flex