### PR TITLE
openssl: fix broken checkout url

### DIFF
--- a/recipes/libs/openssl.yaml
+++ b/recipes/libs/openssl.yaml
@@ -12,7 +12,7 @@ depends:
 
 checkoutSCM:
     scm: url
-    url: https://www.openssl.org/source/openssl-${PKG_VERSION}.tar.gz
+    url: https://www.openssl.org/source/old/1.1.1/openssl-${PKG_VERSION}.tar.gz
     digestSHA256: e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242
     extract: False
 


### PR DESCRIPTION
The path to openssl version 1.1.1.i has been postponed. Adapt the URL to the new path. 