### PR TITLE
Remove /dev/pts mount from sandbox

### DIFF
--- a/classes/sandbox.yaml
+++ b/classes/sandbox.yaml
@@ -66,5 +66,4 @@ provideSandbox:
     paths: ["/usr/bin"]
     mount:
         - "/etc/resolv.conf"
-        - "/dev/pts"
 


### PR DESCRIPTION
the namespace-sandbox in bob 0.24.0 creates its own devpts mount