### PR TITLE
Fix target installation of shared libraries

### DIFF
--- a/classes/install.yaml
+++ b/classes/install.yaml
@@ -10,6 +10,7 @@ inherit: [strip, "basement::bits::libs"]
 # be adapted to promote *.private dependencies to regular dependencies (We do
 # not pass --static to pkg-config.  Executables are still linked dynamically
 # because glibc cannot be linked statically).
+packageVars: [READELF]
 packageSetup: |
     case "$(basementBitsLibraryType)" in
         shared|both)
@@ -132,10 +133,27 @@ packageSetup: |
     installPackageLib()
     {
         if [[ ${INSTALL_SHARED:-} ]] ; then
+            # Copy Windows DLLs unconditionally
             installCopy "$@" /usr/ \
-                /usr/lib/ "/usr/lib/*.so.*" "/usr/lib/lib*-*.so" \
                 /usr/bin/ "/usr/bin/*.dll" "/usr/bin/*.pdb" \
                 "!*"
+            # Be a bit more carefull for UNIX shared objects. Only copy real
+            # files. If the SONAME differs from the file name, create the
+            # symlink too.
+            local d f
+            for d ; do
+                [[ -d "$d/usr/lib" ]] || continue
+                find "$d/usr/lib" -maxdepth 1 -type f -name '*.so*' -print0 \
+                | while IFS= read -r -d $'\0' f ; do
+                    mkdir -p usr/lib
+                    cp -a "$f" "usr/lib/${f##*/}"
+                    soname="$($READELF -d "$f" | sed -En -e '/SONAME/s/[^[]+\[([^]]+)\]/\1/p' || true)"
+                    if [[ -n $soname && $soname != ${f##*/} ]] ; then
+                        ln -sf "${f##*/}" usr/lib/"$soname"
+                    fi
+                done
+            done
+
             installStripAll .
         fi
     }

--- a/default.yaml
+++ b/default.yaml
@@ -33,6 +33,7 @@ environment:
     OBJCOPY: "objcopy"
     OBJDUMP: "objdump"
     RANLIB: "ranlib"
+    READELF: "readelf"
     STRIP: "strip"
 
     # Default host compilation flags. Only cross-compiling target toolchains

--- a/recipes/devel/compat/cross-toolchain.yaml
+++ b/recipes/devel/compat/cross-toolchain.yaml
@@ -31,6 +31,7 @@ provideTools:
             OBJCOPY: "${AUTOCONF_TARGET}-objcopy"
             OBJDUMP: "${AUTOCONF_TARGET}-objdump"
             RANLIB: "${AUTOCONF_TARGET}-ranlib"
+            READELF: "${AUTOCONF_TARGET}-readelf"
             STRIP: "${AUTOCONF_TARGET}-strip"
 
             # meta information

--- a/recipes/devel/cross-toolchain.yaml
+++ b/recipes/devel/cross-toolchain.yaml
@@ -49,6 +49,7 @@ provideTools:
             OBJCOPY: "${AUTOCONF_TARGET}-objcopy"
             OBJDUMP: "${AUTOCONF_TARGET}-objdump"
             RANLIB: "${AUTOCONF_TARGET}-ranlib"
+            READELF: "${AUTOCONF_TARGET}-readelf"
             STRIP: "${AUTOCONF_TARGET}-strip"
 
             # Host system definition. Note that we do not touch the build

--- a/recipes/devel/gcc.yaml
+++ b/recipes/devel/gcc.yaml
@@ -132,6 +132,7 @@ multiPackage:
                     OBJCOPY: "${AUTOCONF_TARGET}-objcopy"
                     OBJDUMP: "${AUTOCONF_TARGET}-objdump"
                     RANLIB: "${AUTOCONF_TARGET}-ranlib"
+                    READELF: "${AUTOCONF_TARGET}-readelf"
                     STRIP: "${AUTOCONF_TARGET}-strip"
 
                     # Host system definition. Note that we do not touch the build

--- a/recipes/devel/host-compat-toolchain.yaml
+++ b/recipes/devel/host-compat-toolchain.yaml
@@ -110,6 +110,7 @@ provideTools:
             OBJCOPY: "${AUTOCONF_TARGET}-objcopy"
             OBJDUMP: "${AUTOCONF_TARGET}-objdump"
             RANLIB: "${AUTOCONF_TARGET}-ranlib"
+            READELF: "${AUTOCONF_TARGET}-readelf"
             STRIP: "${AUTOCONF_TARGET}-strip"
 
             # meta information
@@ -141,6 +142,7 @@ provideTools:
             OBJCOPY: "${AUTOCONF_TARGET}-objcopy"
             OBJDUMP: "${AUTOCONF_TARGET}-objdump"
             RANLIB: "${AUTOCONF_TARGET}-ranlib"
+            READELF: "${AUTOCONF_TARGET}-readelf"
             STRIP: "${AUTOCONF_TARGET}-strip"
 
             # meta information


### PR DESCRIPTION
The old selection of shared libraries for the target relied on the naming. This is unreliable. Instead, look for files and create SONAME links as necessary.