### PR TITLE
cpackage: add cpackageLibraryTypeCheck convenience function

### DIFF
--- a/classes/cpackage.yaml
+++ b/classes/cpackage.yaml
@@ -24,6 +24,21 @@ buildSetup: |
         basementBitsLibraryType
     }
 
+    cpackageLibraryTypeCheck()
+    {
+        case $(cpackageLibraryType) in
+            static)
+                echo "$1"
+                ;;
+            shared)
+                echo "$2"
+                ;;
+            both)
+                echo "$1 $2"
+                ;;
+        esac
+    }
+
     # In case we build on Windows the global paths need to be added to $PATH.
     ${VS_PATH:+export PATH="$PATH:$VS_PATH"}
 


### PR DESCRIPTION
The cpackageLibraryTypeCheck function can be used to get a correct list of input items based on the library type being build. It has two input parameters, the first being the item for the static library case and the second parameter describing an item for the shared library case. Use it like this:

BUILD_TARGETS=$(cpackageLibraryTypeCheck libstatic.a libshared.so)