### PR TITLE
autoconf: Add L4Re OS

### DIFF
--- a/recipes/devel/autoconf/0003-config-sub-add-l4re.patch
+++ b/recipes/devel/autoconf/0003-config-sub-add-l4re.patch
@@ -1,0 +1,12 @@
+diff -urN a/build-aux/config.sub b/build-aux/config.sub
+--- a/build-aux/config.sub	2023-11-30 16:51:33.000000000 +0100
++++ b/build-aux/config.sub	2024-08-08 10:23:18.988353751 +0200
+@@ -1741,7 +1741,7 @@
+ 	     | sym* |  plan9* | psp* | sim* | xray* | os68k* | v88r* \
+ 	     | hiux* | abug | nacl* | netware* | windows* \
+ 	     | os9* | macos* | osx* | ios* | tvos* | watchos* \
+-	     | mpw* | magic* | mmixware* | mon960* | lnews* \
++	     | mpw* | magic* | mmixware* | mon960* | lnews* | l4re* \
+ 	     | amigaos* | amigados* | msdos* | newsos* | unicos* | aof* \
+ 	     | aos* | aros* | cloudabi* | sortix* | twizzler* \
+ 	     | nindy* | vxsim* | vxworks* | ebmon* | hms* | mvs* \


### PR DESCRIPTION
Add the L4Re OS to the config.sub such that it is added to projects when they run autoconf.