### PR TITLE
Add fakeroot library symlink

### DIFF
--- a/recipes/devel/fakeroot.yaml
+++ b/recipes/devel/fakeroot.yaml
@@ -21,5 +21,7 @@ buildScript: |
 
 packageScript: |
     autotoolsPackageTgt
+    # fakeroot manually searches for libfakeroot.so. Make sure the link exists.
+    ln -s libfakeroot-0.so usr/lib/libfakeroot.so
 
 provideDeps: [ "*-tgt" ]


### PR DESCRIPTION
Fakeroot opens its library manually by looking for libfakeroot.so. However, the installed library name is libfakeroot-0.so. autotoolsPackageTgt ignores the installed symlink, because the SONAME is libfakeroot-0. Add the symlink back, so the fakeroot binary finds the library.