### PR TITLE
initial Ada support

### DIFF
--- a/recipes/devel/binutils.yaml
+++ b/recipes/devel/binutils.yaml
@@ -12,31 +12,53 @@ checkoutSCM:
 # Some parts are compiled for the host during compilation. Hence we need the
 # host toolchain too.
 buildTools: [host-toolchain, bison]
+multiPackage:
+    "":
+        buildVars: [AUTOCONF_HOST, AUTOCONF_TARGET, BINUTILS_PREFIX]
+        buildScript: |
+            export MAKEINFO=true
+            autotoolsBuild -o MAKEINFO=true -O MAKEINFO=true $1 \
+                ${BINUTILS_PREFIX:+--prefix=${BINUTILS_PREFIX}} \
+                --with-sysroot=${BINUTILS_PREFIX:-/usr}/sysroots/${AUTOCONF_TARGET:-$AUTOCONF_HOST} \
+                --enable-deterministic-archives \
+                --disable-nls \
+                --disable-werror \
+                --enable-plugins \
+                --enable-lto
 
-buildVars: [AUTOCONF_HOST, AUTOCONF_TARGET, BINUTILS_PREFIX]
-buildScript: |
-    export MAKEINFO=true
-    autotoolsBuild -o MAKEINFO=true -O MAKEINFO=true $1 \
-        ${BINUTILS_PREFIX:+--prefix=${BINUTILS_PREFIX}} \
-        --with-sysroot=${BINUTILS_PREFIX:-/usr}/sysroots/${AUTOCONF_TARGET:-$AUTOCONF_HOST} \
-        --enable-deterministic-archives \
-        --disable-nls \
-        --disable-werror \
-        --enable-plugins \
-        --enable-lto
+        multiPackage:
+            dev:
+                packageScript: |
+                    autotoolsPackageDev
+            "":
+                packageScript: |
+                    autotoolsPackageTgt
 
-packageScript: |
-    autotoolsPackageTgt
+                    # make sure that prefixed versions are available on native build
+                    if [[ $AUTOCONF_HOST = ${AUTOCONF_TARGET:-$AUTOCONF_HOST} ]] ; then
+                        pushd ./${BINUTILS_PREFIX:-/usr}/bin
+                        for i in *; do
+                            ln -s "$i" "${AUTOCONF_HOST}-$i"
+                        done
+                        popd
+                    fi
 
-    # make sure that prefixed versions are available on native build
-    if [[ $AUTOCONF_HOST = ${AUTOCONF_TARGET:-$AUTOCONF_HOST} ]] ; then
-        pushd ./${BINUTILS_PREFIX:-/usr}/bin
-        for i in *; do
-            ln -s "$i" "${AUTOCONF_HOST}-$i"
-        done
-        popd
-    fi
+                provideTools:
+                    binutils: usr/bin
 
-provideTools:
-    binutils: usr/bin
+    libiberty:
+        depends:
+            - devel::binutils-dev
+        buildScript: |
+            autotoolsBuild $1/libiberty \
+                --enable-install-libiberty
+            if [[ -e install/usr/lib64 ]]; then
+                mkdir -p install/usr/lib
+                mv install/usr/lib64/* install/usr/lib
+            fi
+        multiPackage:
+            dev:
+                packageScript: autotoolsPackageDev
+            tgt:
+                packageScript: autotoolsPackageTgt
 

--- a/recipes/devel/cross-toolchain.yaml
+++ b/recipes/devel/cross-toolchain.yaml
@@ -106,6 +106,15 @@ multiPackage:
             GCC_TARGET_ARCH: "armv8-a"
             GCC_LIBC: "glibc"
 
+    # ARMv8-A AArch64 Linux toolchain with ada
+    aarch64-linux-gnu-ada:
+        environment:
+            AUTOCONF_TARGET: "aarch64-linux-gnu"
+            ARCH: "arm64"
+            GCC_TARGET_ARCH: "armv8-a"
+            GCC_LIBC: "glibc"
+            GCC_ENABLE_LANGUAGES: "c,c++,ada"
+
     # ARMv8-A/R AArch64 bare metal toolchain
     aarch64-none-elf:
         environment:

--- a/recipes/devel/gcc.yaml
+++ b/recipes/devel/gcc.yaml
@@ -227,8 +227,12 @@ multiPackage:
                 buildTools: [host-toolchain, target-toolchain, cross-ambient-toolchain]
                 buildScript: |
                     cp -a "${BOB_TOOL_PATHS[cross-ambient-toolchain]}/../.."/* install/
-                    makeParallel -C build all-gcc
-                    makeSequential -C build install-gcc DESTDIR="$PWD/install"
+                    if [[ ${GCC_ENABLE_LANGUAGES:-c,c+} == *"ada"* ]]; then
+                        ADDITIONAL_MAKE=(all-gnattools)
+                        ADDITIONAL_INSTALL=(install-gnattools)
+                    fi
+                    makeParallel -C build all-gcc ${ADDITIONAL_MAKE[@]}
+                    makeSequential -C build install-gcc ${ADDITIONAL_INSTALL[@]} DESTDIR="$PWD/install"
 
     native:
         buildTools: [host-toolchain, target-toolchain]

--- a/recipes/devel/meson.yaml
+++ b/recipes/devel/meson.yaml
@@ -1,12 +1,12 @@
 inherit: [python3-pkg]
 
 metaEnvironment:
-    PKG_VERSION: "1.4.1"
+    PKG_VERSION: "1.5.1"
 
 checkoutSCM:
     scm: url
     url: ${GITHUB_MIRROR}/mesonbuild/meson/releases/download/${PKG_VERSION}/meson-${PKG_VERSION}.tar.gz
-    digestSHA256: 1b8aad738a5f6ae64294cc8eaba9a82988c1c420204484ac02ef782e5bba5f49
+    digestSHA256: 567e533adf255de73a2de35049b99923caf872a455af9ce03e01077e0d384bed
     stripComponents: 1
 
 buildScript: |


### PR DESCRIPTION
This adds support for building a cross-toolchain with ada-language enabled. 

As a gnat-compiler is needed to build gcc with gnat this needs to be setup before. There is a ada-layer at https://github.com/rhubert/layers-ada which uses `alr` to download the gnat-compiler from adacore. 
Using the gnat-toolchain from this layer will not change the target / host-toolchain setting. Instead it provides a `gnat-host-toolchain` and a `gnat-target-toolchain` (based on gcc-13.2). 

This is because we still want to use the `host-compat-toolchain` for all non-ada components - otherwise these tools won't be run-able on older systems.
OTOH we don't want to build + use the `host-compat-toolchain` with ada and use this for the ada-host-tools because they are using the latest ada-features + fixes.

To build a ada-enabled cross toolchain use:
```yaml
inherit: [basement::rootrecipe]

depends:
    - name: adacore::alr
      use: [tools]
      forward: True

    - name: adacore::gnat-x86_64-pc-linux-gnu
      use: [tools]
      forward: True

    - name: devel::cross-toolchain-aarch64-linux-gnu-ada    
      use: [tools]    
      forward: True    
      tools:    
        target-toolchain: gnat-host-toolchain    
        host-native-toolchain: gnat-host-toolchain    
```