### PR TITLE
openssl version bump and cleanup

### DIFF
--- a/recipes/libs/openssl.yaml
+++ b/recipes/libs/openssl.yaml
@@ -1,7 +1,7 @@
 inherit: [cpackage, make, install, patch]
 
 metaEnvironment:
-    PKG_VERSION: "3.2.1"
+    PKG_VERSION: "3.3.1"
 
 depends:
     - libs::zlib-dev
@@ -13,7 +13,7 @@ depends:
 checkoutSCM:
     scm: url
     url: https://www.openssl.org/source/openssl-${PKG_VERSION}.tar.gz
-    digestSHA256: 83c7329fe52c850677d75e5d0b0ca245309b97e8ecbcfdc1dfdc4ab9fac35b39
+    digestSHA256: 777cd596284c883375a2a7a11bf5d2786fc5413255efab20c50d6ffe6d020b7e
     stripComponents: 1
 
 checkoutDeterministic: True

--- a/recipes/libs/openssl.yaml
+++ b/recipes/libs/openssl.yaml
@@ -23,8 +23,6 @@ checkoutScript: |
 buildTools: [target-toolchain]
 buildVars: [CC, AR, RANLIB, ARCH, AUTOCONF_HOST]
 buildScript: |
-    export TARGETMACH=${AUTOCONF_HOST}
-
     mkdir -p install build
     pushd build
 


### PR DESCRIPTION
This bumps openssl to 3.3.1 and removes a variable assignment that is not needed anymore.