### PR TITLE
libs/openssl: fix pkg-config files

### DIFF
--- a/recipes/libs/openssl/0002-Adapt-all-the-exporter-files-to-the-new-vars-from-ut.patch
+++ b/recipes/libs/openssl/0002-Adapt-all-the-exporter-files-to-the-new-vars-from-ut.patch
@@ -1,0 +1,96 @@
+From 1c437b5704c9ee5f667bc2b11e5fdf176dfb714f Mon Sep 17 00:00:00 2001
+From: Richard Levitte <levitte@openssl.org>
+Date: Thu, 20 Jun 2024 14:33:15 +0200
+Subject: [PATCH] Adapt all the exporter files to the new vars from
+ util/mkinstallvars.pl
+
+With this, the pkg-config files take better advantage of relative directory
+values.
+
+Fixes #24298
+
+Reviewed-by: Neil Horman <nhorman@openssl.org>
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/24687)
+
+(cherry picked from commit 30dc37d798a0428fd477d3763086e7e97b3d596f)
+---
+ exporters/cmake/OpenSSLConfig.cmake.in |  7 ++++---
+ exporters/pkg-config/libcrypto.pc.in   | 12 ++++++++----
+ exporters/pkg-config/libssl.pc.in      |  8 ++++++--
+ exporters/pkg-config/openssl.pc.in     |  8 ++++++--
+ 4 files changed, 24 insertions(+), 11 deletions(-)
+
+diff --git a/exporters/cmake/OpenSSLConfig.cmake.in b/exporters/cmake/OpenSSLConfig.cmake.in
+index 2d2321931d..06f796158b 100644
+--- a/exporters/cmake/OpenSSLConfig.cmake.in
++++ b/exporters/cmake/OpenSSLConfig.cmake.in
+@@ -89,9 +89,10 @@ unset(_ossl_undefined_targets)
+ # Set up the import path, so all other import paths are made relative this file
+ get_filename_component(_ossl_prefix "${CMAKE_CURRENT_LIST_FILE}" PATH)
+ {-
+-  # For each component in $OpenSSL::safe::installdata::CMAKECONFIGDIR_REL, have CMake
+-  # out the parent directory.
+-  my $d = unixify($OpenSSL::safe::installdata::CMAKECONFIGDIR_REL);
++  # For each component in $OpenSSL::safe::installdata::CMAKECONFIGDIR relative to
++  # $OpenSSL::safe::installdata::PREFIX, have CMake figure out the parent directory.
++  my $d = join('/', unixify($OpenSSL::safe::installdata::LIBDIR_REL_PREFIX),
++                    unixify($OpenSSL::safe::installdata::CMAKECONFIGDIR_REL_LIBDIR));
+   $OUT = '';
+   $OUT .= 'get_filename_component(_ossl_prefix "${_ossl_prefix}" PATH)' . "\n"
+       foreach (split '/', $d);
+diff --git a/exporters/pkg-config/libcrypto.pc.in b/exporters/pkg-config/libcrypto.pc.in
+index 14ed339f3c..fbc8ea4c79 100644
+--- a/exporters/pkg-config/libcrypto.pc.in
++++ b/exporters/pkg-config/libcrypto.pc.in
+@@ -1,7 +1,11 @@
+-libdir={- $OpenSSL::safe::installdata::LIBDIR -}
+-includedir={- $OpenSSL::safe::installdata::INCLUDEDIR -}
+-enginesdir={- $OpenSSL::safe::installdata::ENGINESDIR -}
+-modulesdir={- $OpenSSL::safe::installdata::MODULESDIR -}
++prefix={- $OpenSSL::safe::installdata::PREFIX -}
++exec_prefix=${prefix}
++libdir={- $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX
++          ? '${exec_prefix}/' . $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX
++          : $OpenSSL::safe::installdata::libdir -}
++includedir=${prefix}/{- $OpenSSL::safe::installdata::INCLUDEDIR_REL_PREFIX -}
++enginesdir=${libdir}/{- $OpenSSL::safe::installdata::ENGINESDIR_REL_LIBDIR -}
++modulesdir=${libdir}/{- $OpenSSL::safe::installdata::MODULESDIR_REL_LIBDIR -}
+ 
+ Name: OpenSSL-libcrypto
+ Description: OpenSSL cryptography library
+diff --git a/exporters/pkg-config/libssl.pc.in b/exporters/pkg-config/libssl.pc.in
+index a7828b3cc6..963538807b 100644
+--- a/exporters/pkg-config/libssl.pc.in
++++ b/exporters/pkg-config/libssl.pc.in
+@@ -1,5 +1,9 @@
+-libdir={- $OpenSSL::safe::installdata::LIBDIR -}
+-includedir={- $OpenSSL::safe::installdata::INCLUDEDIR -}
++prefix={- $OpenSSL::safe::installdata::PREFIX -}
++exec_prefix=${prefix}
++libdir={- $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX
++          ? '${exec_prefix}/' . $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX
++          : $OpenSSL::safe::installdata::libdir -}
++includedir=${prefix}/{- $OpenSSL::safe::installdata::INCLUDEDIR_REL_PREFIX -}
+ 
+ Name: OpenSSL-libssl
+ Description: Secure Sockets Layer and cryptography libraries
+diff --git a/exporters/pkg-config/openssl.pc.in b/exporters/pkg-config/openssl.pc.in
+index dbb77aa39a..225bef9e23 100644
+--- a/exporters/pkg-config/openssl.pc.in
++++ b/exporters/pkg-config/openssl.pc.in
+@@ -1,5 +1,9 @@
+-libdir={- $OpenSSL::safe::installdata::LIBDIR -}
+-includedir={- $OpenSSL::safe::installdata::INCLUDEDIR -}
++prefix={- $OpenSSL::safe::installdata::PREFIX -}
++exec_prefix=${prefix}
++libdir={- $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX
++          ? '${exec_prefix}/' . $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX
++          : $OpenSSL::safe::installdata::libdir -}
++includedir=${prefix}/{- $OpenSSL::safe::installdata::INCLUDEDIR_REL_PREFIX -}
+ 
+ Name: OpenSSL
+ Description: Secure Sockets Layer and cryptography libraries and tools
+-- 
+2.39.2
+

--- a/recipes/libs/openssl/0003-Fix-cmake-generator.patch
+++ b/recipes/libs/openssl/0003-Fix-cmake-generator.patch
@@ -1,0 +1,64 @@
+From 419fb4ea4be4c0b28c63b494ff30fa3510aba06e Mon Sep 17 00:00:00 2001
+From: Neil Horman <nhorman@openssl.org>
+Date: Sun, 14 Jul 2024 08:57:25 -0400
+Subject: [PATCH] Fix cmake generator
+
+PR #24678 modified some environment variables and locations that the
+cmake exporter depended on, resulting in empty directory resolution.
+Adjust build build.info and input variable names to match up again
+
+Fixes #24874
+
+Reviewed-by: Richard Levitte <levitte@openssl.org>
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/24877)
+
+(cherry picked from commit c1a27bdeb9a4f915aa92ed0e74ed48a1f9b94176)
+---
+ build.info                             |  5 +++++
+ exporters/cmake/OpenSSLConfig.cmake.in | 12 ++++++------
+ 2 files changed, 11 insertions(+), 6 deletions(-)
+
+diff --git a/build.info b/build.info
+index 790f2421e5..b578af4b19 100644
+--- a/build.info
++++ b/build.info
+@@ -102,6 +102,11 @@ IF[{- $config{target} =~ /^(?:Cygwin|mingw|VC-|BC-)/ -}]
+ ENDIF
+ 
+ # This file sets the build directory up for CMake inclusion
++# Note: This generation of OpenSSLConfig[Version].cmake is used
++# for building openssl locally, and so the build variables are 
++# taken from builddata.pm rather than installdata.pm.  For exportable
++# versions of these generated files, you'll find them in the exporters
++# directory
+ GENERATE[OpenSSLConfig.cmake]=exporters/cmake/OpenSSLConfig.cmake.in
+ DEPEND[OpenSSLConfig.cmake]=builddata.pm
+ GENERATE[OpenSSLConfigVersion.cmake]=exporters/cmake/OpenSSLConfigVersion.cmake.in
+diff --git a/exporters/cmake/OpenSSLConfig.cmake.in b/exporters/cmake/OpenSSLConfig.cmake.in
+index 06f796158b..b35a58152d 100644
+--- a/exporters/cmake/OpenSSLConfig.cmake.in
++++ b/exporters/cmake/OpenSSLConfig.cmake.in
+@@ -127,13 +127,13 @@ set(OPENSSL_VERSION_FIX "${OpenSSL_VERSION_PATCH}")
+ set(OPENSSL_FOUND YES)
+ 
+ # Directories and names
+-set(OPENSSL_INCLUDE_DIR "${_ossl_prefix}/{- unixify($OpenSSL::safe::installdata::INCLUDEDIR_REL, 1); -}")
+-set(OPENSSL_LIBRARY_DIR "${_ossl_prefix}/{- unixify($OpenSSL::safe::installdata::LIBDIR_REL, 1); -}")
+-set(OPENSSL_ENGINES_DIR "${_ossl_prefix}/{- unixify($OpenSSL::safe::installdata::ENGINESDIR_REL, 1); -}")
+-set(OPENSSL_MODULES_DIR "${_ossl_prefix}/{- unixify($OpenSSL::safe::installdata::MODULESDIR_REL, 1); -}")
+-set(OPENSSL_RUNTIME_DIR "${_ossl_prefix}/{- unixify($OpenSSL::safe::installdata::BINDIR_REL, 1); -}")
++set(OPENSSL_LIBRARY_DIR "${_ossl_prefix}/{- unixify($OpenSSL::safe::installdata::LIBDIR_REL_PREFIX, 1); -}")
++set(OPENSSL_INCLUDE_DIR "${_ossl_prefix}/{- unixify($OpenSSL::safe::installdata::INCLUDEDIR_REL_PREFIX, 1); -}")
++set(OPENSSL_ENGINES_DIR "${_ossl_prefix}/{- unixify($OpenSSL::safe::installdata::LIBDIR_REL_PREFIX, 1); -}/{- unixify($OpenSSL::safe::installdata::ENGINESDIR_REL_LIBDIR, 1); -}")
++set(OPENSSL_MODULES_DIR "${_ossl_prefix}/{- unixify($OpenSSL::safe::installdata::LIBDIR_REL_PREFIX, 1); -}/{- unixify($OpenSSL::safe::installdata::MODULESDIR_REL_LIBDIR, 1); -}")
++set(OPENSSL_RUNTIME_DIR "${_ossl_prefix}/{- unixify($OpenSSL::safe::installdata::BINDIR_REL_PREFIX, 1); -}")
+ {- output_off() if $disabled{uplink}; "" -}
+-set(OPENSSL_APPLINK_SOURCE "${_ossl_prefix}/{- unixify($OpenSSL::safe::installdata::APPLINKDIR_REL, 1); -}/applink.c")
++set(OPENSSL_APPLINK_SOURCE "${_ossl_prefix}/{- unixify($OpenSSL::safe::installdata::APPLINKDIR_REL_PREFIX, 1); -}/applink.c")
+ {- output_on() if $disabled{uplink}; "" -}
+ set(OPENSSL_PROGRAM "${OPENSSL_RUNTIME_DIR}/{- platform->bin('openssl') -}")
+ 
+-- 
+2.39.2
+

--- a/recipes/libs/openssl/0004-fix-exporters-cmake-OpenSSLConfig.cmake.in-to-work-f.patch
+++ b/recipes/libs/openssl/0004-fix-exporters-cmake-OpenSSLConfig.cmake.in-to-work-f.patch
@@ -1,0 +1,52 @@
+From 27b00ac152a1d6940b9838f81b6daefdfcd84dbe Mon Sep 17 00:00:00 2001
+From: Richard Levitte <levitte@openssl.org>
+Date: Wed, 17 Jul 2024 11:09:11 +0200
+Subject: [PATCH] fix: exporters/cmake/OpenSSLConfig.cmake.in to work for build
+ config
+
+This template file is made to make both:
+
+1. OpenSSLConfig.cmake (CMake config used when building a CMake package
+   against an uninstalled OpenSSL build)
+2. exporters/OpenSSLConfig.cmake (CMake config that's to be installed
+   alongside OpenSSL, and is used when building a CMake package against
+   an OpenSSL installation).
+
+Variant 1 was unfortunately getting the internal '_ossl_prefix' variable
+wrong, which is due to how the perl snippet builds the command(s) to figure
+out its value.  That needed some correction.
+
+Reviewed-by: Neil Horman <nhorman@openssl.org>
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/24918)
+
+(cherry picked from commit a82d9e572cc757e4fa50d484bfbb7115f2d027dd)
+---
+ exporters/cmake/OpenSSLConfig.cmake.in | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/exporters/cmake/OpenSSLConfig.cmake.in b/exporters/cmake/OpenSSLConfig.cmake.in
+index b35a58152d..dc9927a762 100644
+--- a/exporters/cmake/OpenSSLConfig.cmake.in
++++ b/exporters/cmake/OpenSSLConfig.cmake.in
+@@ -91,11 +91,13 @@ get_filename_component(_ossl_prefix "${CMAKE_CURRENT_LIST_FILE}" PATH)
+ {-
+   # For each component in $OpenSSL::safe::installdata::CMAKECONFIGDIR relative to
+   # $OpenSSL::safe::installdata::PREFIX, have CMake figure out the parent directory.
+-  my $d = join('/', unixify($OpenSSL::safe::installdata::LIBDIR_REL_PREFIX),
+-                    unixify($OpenSSL::safe::installdata::CMAKECONFIGDIR_REL_LIBDIR));
++  my $d = join('/', unixify(catdir($OpenSSL::safe::installdata::LIBDIR_REL_PREFIX,
++                                   $OpenSSL::safe::installdata::CMAKECONFIGDIR_REL_LIBDIR), 1));
+   $OUT = '';
+-  $OUT .= 'get_filename_component(_ossl_prefix "${_ossl_prefix}" PATH)' . "\n"
+-      foreach (split '/', $d);
++  if ($d ne '.') {
++      $OUT .= 'get_filename_component(_ossl_prefix "${_ossl_prefix}" PATH)' . "\n"
++          foreach (split '/', $d);
++  }
+ -}
+ if(_ossl_prefix STREQUAL "/")
+   set(_ossl_prefix "")
+-- 
+2.39.2
+

--- a/recipes/libs/openssl/0005-Give-util-mkinstallvars.pl-more-fine-grained-control.patch
+++ b/recipes/libs/openssl/0005-Give-util-mkinstallvars.pl-more-fine-grained-control.patch
@@ -1,0 +1,206 @@
+From aa099dba7c80c723cf4babf5adc0c801f1c28363 Mon Sep 17 00:00:00 2001
+From: Richard Levitte <levitte@openssl.org>
+Date: Thu, 20 Jun 2024 14:30:16 +0200
+Subject: [PATCH] Give util/mkinstallvars.pl more fine grained control over var
+ dependencies
+
+Essentially, we try to do what GNU does.  'prefix' is used to define the
+defaults for 'exec_prefix' and 'libdir', and these are then used to define
+further directory values.  util/mkinstallvars.pl is changed to reflect that
+to the best of our ability.
+
+Reviewed-by: Neil Horman <nhorman@openssl.org>
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/24687)
+
+(cherry picked from commit 6e0fd246e7a6e51f92b2ef3520bfc4414b7773c0)
+---
+ exporters/build.info  |   2 +-
+ util/mkinstallvars.pl | 133 ++++++++++++++++++++++++++----------------
+ 2 files changed, 85 insertions(+), 50 deletions(-)
+
+diff --git a/exporters/build.info b/exporters/build.info
+index 86acf2df94..9241dc9b0a 100644
+--- a/exporters/build.info
++++ b/exporters/build.info
+@@ -19,7 +19,7 @@ DEPEND[openssl.pc]=libcrypto.pc libssl.pc
+ DEPEND[""]=openssl.pc
+ 
+ GENERATE[../installdata.pm]=../util/mkinstallvars.pl \
+-    "PREFIX=$(INSTALLTOP)" BINDIR=bin "LIBDIR=$(LIBDIR)" \
++    "PREFIX=$(INSTALLTOP)" BINDIR=bin "LIBDIR=$(LIBDIR)" "libdir=$(libdir)" \
+     INCLUDEDIR=include APPLINKDIR=include/openssl \
+     "ENGINESDIR=$(ENGINESDIR)" "MODULESDIR=$(MODULESDIR)" \
+     "PKGCONFIGDIR=$(PKGCONFIGDIR)" "CMAKECONFIGDIR=$(CMAKECONFIGDIR)" \
+diff --git a/util/mkinstallvars.pl b/util/mkinstallvars.pl
+index 59a432d28c..5fadb708e1 100644
+--- a/util/mkinstallvars.pl
++++ b/util/mkinstallvars.pl
+@@ -11,13 +11,25 @@
+ # The result is a Perl module creating the package OpenSSL::safe::installdata.
+ 
+ use File::Spec;
++use List::Util qw(pairs);
+ 
+ # These are expected to be set up as absolute directories
+-my @absolutes = qw(PREFIX);
++my @absolutes = qw(PREFIX libdir);
+ # These may be absolute directories, and if not, they are expected to be set up
+-# as subdirectories to PREFIX
+-my @subdirs = qw(BINDIR LIBDIR INCLUDEDIR APPLINKDIR ENGINESDIR MODULESDIR
+-                 PKGCONFIGDIR CMAKECONFIGDIR);
++# as subdirectories to PREFIX or LIBDIR.  The order of the pairs is important,
++# since the LIBDIR subdirectories depend on the calculation of LIBDIR from
++# PREFIX.
++my @subdirs = pairs (PREFIX => [ qw(BINDIR LIBDIR INCLUDEDIR APPLINKDIR) ],
++                     LIBDIR => [ qw(ENGINESDIR MODULESDIR PKGCONFIGDIR
++                                    CMAKECONFIGDIR) ]);
++# For completeness, other expected variables
++my @others = qw(VERSION LDLIBS);
++
++my %all = ( );
++foreach (@absolutes) { $all{$_} = 1 }
++foreach (@subdirs) { foreach (@{$_->[1]}) { $all{$_} = 1 } }
++foreach (@others) { $all{$_} = 1 }
++print STDERR "DEBUG: all keys: ", join(", ", sort keys %all), "\n";
+ 
+ my %keys = ();
+ foreach (@ARGV) {
+@@ -26,29 +38,47 @@ foreach (@ARGV) {
+     $ENV{$k} = $v;
+ }
+ 
+-foreach my $k (sort keys %keys) {
+-    my $v = $ENV{$k};
+-    $v = File::Spec->rel2abs($v) if $v && grep { $k eq $_ } @absolutes;
+-    $ENV{$k} = $v;
++# warn if there are missing values, and also if there are unexpected values
++foreach my $k (sort keys %all) {
++    warn "No value given for $k\n" unless $keys{$k};
+ }
+ foreach my $k (sort keys %keys) {
++    warn "Unknown variable $k\n" unless $all{$k};
++}
++
++# This shouldn't be needed, but just in case we get relative paths that
++# should be absolute, make sure they actually are.
++foreach my $k (@absolutes) {
+     my $v = $ENV{$k} || '.';
++    print STDERR "DEBUG: $k = $v => ";
++    $v = File::Spec->rel2abs($v) if $v;
++    $ENV{$k} = $v;
++    print STDERR "$k = $ENV{$k}\n";
++}
+ 
+-    # Absolute paths for the subdir variables are computed.  This provides
+-    # the usual form of values for names that have become norm, known as GNU
+-    # installation paths.
+-    # For the benefit of those that need it, the subdirectories are preserved
+-    # as they are, using the same variable names, suffixed with '_REL', if they
+-    # are indeed subdirectories.
+-    if (grep { $k eq $_ } @subdirs) {
++# Absolute paths for the subdir variables are computed.  This provides
++# the usual form of values for names that have become norm, known as GNU
++# installation paths.
++# For the benefit of those that need it, the subdirectories are preserved
++# as they are, using the same variable names, suffixed with '_REL_{var}',
++# if they are indeed subdirectories.  The '{var}' part of the name tells
++# which other variable value they are relative to.
++foreach my $pair (@subdirs) {
++    my ($var, $subdir_vars) = @$pair;
++    foreach my $k (@$subdir_vars) {
++        my $v = $ENV{$k} || '.';
++        print STDERR "DEBUG: $k = $v => ";
+         if (File::Spec->file_name_is_absolute($v)) {
+-            $ENV{"${k}_REL"} = File::Spec->abs2rel($v, $ENV{PREFIX});
++            my $kr = "${k}_REL_${var}";
++            $ENV{$kr} = File::Spec->abs2rel($v, $ENV{$var});
++            print STDERR "$kr = $ENV{$kr}\n";
+         } else {
+-            $ENV{"${k}_REL"} = $v;
+-            $v = File::Spec->rel2abs($v, $ENV{PREFIX});
++            my $kr = "${k}_REL_${var}";
++            $ENV{$kr} = $v;
++            $ENV{$k} = File::Spec->rel2abs($v, $ENV{$var});
++            print STDERR "$k = $ENV{$k} ,  $kr = $v\n";
+         }
+     }
+-    $ENV{$k} = $v;
+ }
+ 
+ print <<_____;
+@@ -58,36 +88,41 @@ use strict;
+ use warnings;
+ use Exporter;
+ our \@ISA = qw(Exporter);
+-our \@EXPORT = qw(\$PREFIX
+-                  \$BINDIR \$BINDIR_REL
+-                  \$LIBDIR \$LIBDIR_REL
+-                  \$INCLUDEDIR \$INCLUDEDIR_REL
+-                  \$APPLINKDIR \$APPLINKDIR_REL
+-                  \$ENGINESDIR \$ENGINESDIR_REL
+-                  \$MODULESDIR \$MODULESDIR_REL
+-                  \$PKGCONFIGDIR \$PKGCONFIGDIR_REL
+-                  \$CMAKECONFIGDIR \$CMAKECONFIGDIR_REL
+-                  \$VERSION \@LDLIBS);
+-
+-our \$PREFIX             = '$ENV{PREFIX}';
+-our \$BINDIR             = '$ENV{BINDIR}';
+-our \$BINDIR_REL         = '$ENV{BINDIR_REL}';
+-our \$LIBDIR             = '$ENV{LIBDIR}';
+-our \$LIBDIR_REL         = '$ENV{LIBDIR_REL}';
+-our \$INCLUDEDIR         = '$ENV{INCLUDEDIR}';
+-our \$INCLUDEDIR_REL     = '$ENV{INCLUDEDIR_REL}';
+-our \$APPLINKDIR         = '$ENV{APPLINKDIR}';
+-our \$APPLINKDIR_REL     = '$ENV{APPLINKDIR_REL}';
+-our \$ENGINESDIR         = '$ENV{ENGINESDIR}';
+-our \$ENGINESDIR_REL     = '$ENV{ENGINESDIR_REL}';
+-our \$MODULESDIR         = '$ENV{MODULESDIR}';
+-our \$MODULESDIR_REL     = '$ENV{MODULESDIR_REL}';
+-our \$PKGCONFIGDIR       = '$ENV{PKGCONFIGDIR}';
+-our \$PKGCONFIGDIR_REL   = '$ENV{PKGCONFIGDIR_REL}';
+-our \$CMAKECONFIGDIR     = '$ENV{CMAKECONFIGDIR}';
+-our \$CMAKECONFIGDIR_REL = '$ENV{CMAKECONFIGDIR_REL}';
+-our \$VERSION            = '$ENV{VERSION}';
+-our \@LDLIBS             =
++our \@EXPORT = qw(
++_____
++
++foreach my $k (@absolutes) {
++    print "    \$$k\n";
++}
++foreach my $pair (@subdirs) {
++    my ($var, $subdir_vars) = @$pair;
++    foreach my $k (@$subdir_vars) {
++        my $k2 = "${k}_REL_${var}";
++        print "    \$$k \$$k2\n";
++    }
++}
++
++print <<_____;
++    \$VERSION \@LDLIBS
++);
++
++_____
++
++foreach my $k (@absolutes) {
++    print "our \$$k" . ' ' x (27 - length($k)) . "= '$ENV{$k}';\n";
++}
++foreach my $pair (@subdirs) {
++    my ($var, $subdir_vars) = @$pair;
++    foreach my $k (@$subdir_vars) {
++        my $k2 = "${k}_REL_${var}";
++        print "our \$$k" . ' ' x (27 - length($k)) . "= '$ENV{$k}';\n";
++        print "our \$$k2" . ' ' x (27 - length($k2)) . "= '$ENV{$k2}';\n";
++    }
++}
++
++print <<_____;
++our \$VERSION                    = '$ENV{VERSION}';
++our \@LDLIBS                     =
+     # Unix and Windows use space separation, VMS uses comma separation
+     split(/ +| *, */, '$ENV{LDLIBS}');
+ 
+-- 
+2.39.2
+

--- a/recipes/libs/openssl/0006-fix-util-mkinstallvars.pl-mistreated-LDLIBS-on-Unix-.patch
+++ b/recipes/libs/openssl/0006-fix-util-mkinstallvars.pl-mistreated-LDLIBS-on-Unix-.patch
@@ -1,0 +1,38 @@
+From 293650d33069276446b286ad856cfb9854ea83e4 Mon Sep 17 00:00:00 2001
+From: Richard Levitte <levitte@openssl.org>
+Date: Sun, 28 Jul 2024 10:47:08 +0200
+Subject: [PATCH] fix: util/mkinstallvars.pl mistreated LDLIBS on Unix (and
+ Windows)
+
+Don't do comma separation on those platforms.
+
+Fixes #24986
+
+Reviewed-by: Neil Horman <nhorman@openssl.org>
+Reviewed-by: Matt Caswell <matt@openssl.org>
+Reviewed-by: Tom Cosgrove <tom.cosgrove@arm.com>
+(Merged from https://github.com/openssl/openssl/pull/25018)
+
+(cherry picked from commit 0beef0ba00f7864b7367899d859509a99237fcf0)
+---
+ util/mkinstallvars.pl | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/util/mkinstallvars.pl b/util/mkinstallvars.pl
+index 5fadb708e1..e2b7d9d083 100644
+--- a/util/mkinstallvars.pl
++++ b/util/mkinstallvars.pl
+@@ -124,7 +124,9 @@ print <<_____;
+ our \$VERSION                    = '$ENV{VERSION}';
+ our \@LDLIBS                     =
+     # Unix and Windows use space separation, VMS uses comma separation
+-    split(/ +| *, */, '$ENV{LDLIBS}');
++    \$^O eq 'VMS'
++    ? split(/ *, */, '$ENV{LDLIBS}')
++    : split(/ +/, '$ENV{LDLIBS}');
+ 
+ 1;
+ _____
+-- 
+2.39.2
+

--- a/recipes/libs/openssl/0007-fix-for-exporters-to-work-for-build-config-there-may.patch
+++ b/recipes/libs/openssl/0007-fix-for-exporters-to-work-for-build-config-there-may.patch
@@ -1,0 +1,278 @@
+From 7a122cafc1415e1f182fd58b36708b5a08fb8550 Mon Sep 17 00:00:00 2001
+From: Richard Levitte <levitte@openssl.org>
+Date: Wed, 17 Jul 2024 18:23:57 +0200
+Subject: [PATCH] fix: for exporters to work for build config, there may be two
+ include dirs
+
+For CMake / pkg-config configuration files to be used for an uninstalled
+build, the include directory in the build directory isn't enough, if that
+one is separate from the source directory.  The include directory in the
+source directory must be accounted for too.
+
+This includes some lighter refactoring of util/mkinstallvars.pl, with the
+result that almost all variables in builddata.pm and installdata.pm have
+become arrays, even though unnecessarily for most of them; it was simpler
+that way.  The CMake / pkg-config templates are adapted accordingly.
+
+Reviewed-by: Neil Horman <nhorman@openssl.org>
+Reviewed-by: Tomas Mraz <tomas@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/24918)
+
+(cherry picked from commit accd835f8d6ed946eb540a3e2e82f9723093f094)
+---
+ build.info                             |  3 +-
+ exporters/cmake/OpenSSLConfig.cmake.in | 22 ++++----
+ exporters/pkg-config/libcrypto.pc.in   | 23 ++++++---
+ exporters/pkg-config/libssl.pc.in      | 11 +++-
+ util/mkinstallvars.pl                  | 71 +++++++++++++++++---------
+ 5 files changed, 84 insertions(+), 46 deletions(-)
+
+diff --git a/build.info b/build.info
+index b578af4b19..930a0a940c 100644
+--- a/build.info
++++ b/build.info
+@@ -124,7 +124,8 @@ DEPEND[openssl.pc]=builddata.pm
+ DEPEND[openssl.pc]=libcrypto.pc libssl.pc
+ 
+ GENERATE[builddata.pm]=util/mkinstallvars.pl \
+-    PREFIX=. BINDIR=apps LIBDIR= INCLUDEDIR=include APPLINKDIR=ms \
++    PREFIX=. BINDIR=apps APPLINKDIR=ms \
++    LIBDIR= INCLUDEDIR=include "INCLUDEDIR=$(SRCDIR)/include" \
+     ENGINESDIR=engines MODULESDIR=providers \
+     "VERSION=$(VERSION)" "LDLIBS=$(LIB_EX_LIBS)"
+ 
+diff --git a/exporters/cmake/OpenSSLConfig.cmake.in b/exporters/cmake/OpenSSLConfig.cmake.in
+index dc9927a762..766aebe3d4 100644
+--- a/exporters/cmake/OpenSSLConfig.cmake.in
++++ b/exporters/cmake/OpenSSLConfig.cmake.in
+@@ -89,10 +89,10 @@ unset(_ossl_undefined_targets)
+ # Set up the import path, so all other import paths are made relative this file
+ get_filename_component(_ossl_prefix "${CMAKE_CURRENT_LIST_FILE}" PATH)
+ {-
+-  # For each component in $OpenSSL::safe::installdata::CMAKECONFIGDIR relative to
+-  # $OpenSSL::safe::installdata::PREFIX, have CMake figure out the parent directory.
+-  my $d = join('/', unixify(catdir($OpenSSL::safe::installdata::LIBDIR_REL_PREFIX,
+-                                   $OpenSSL::safe::installdata::CMAKECONFIGDIR_REL_LIBDIR), 1));
++  # For each component in $OpenSSL::safe::installdata::CMAKECONFIGDIR[0] relative to
++  # $OpenSSL::safe::installdata::PREFIX[0], have CMake figure out the parent directory.
++  my $d = join('/', unixify(catdir($OpenSSL::safe::installdata::LIBDIR_REL_PREFIX[0],
++                                   $OpenSSL::safe::installdata::CMAKECONFIGDIR_REL_LIBDIR[0]), 1));
+   $OUT = '';
+   if ($d ne '.') {
+       $OUT .= 'get_filename_component(_ossl_prefix "${_ossl_prefix}" PATH)' . "\n"
+@@ -129,13 +129,15 @@ set(OPENSSL_VERSION_FIX "${OpenSSL_VERSION_PATCH}")
+ set(OPENSSL_FOUND YES)
+ 
+ # Directories and names
+-set(OPENSSL_LIBRARY_DIR "${_ossl_prefix}/{- unixify($OpenSSL::safe::installdata::LIBDIR_REL_PREFIX, 1); -}")
+-set(OPENSSL_INCLUDE_DIR "${_ossl_prefix}/{- unixify($OpenSSL::safe::installdata::INCLUDEDIR_REL_PREFIX, 1); -}")
+-set(OPENSSL_ENGINES_DIR "${_ossl_prefix}/{- unixify($OpenSSL::safe::installdata::LIBDIR_REL_PREFIX, 1); -}/{- unixify($OpenSSL::safe::installdata::ENGINESDIR_REL_LIBDIR, 1); -}")
+-set(OPENSSL_MODULES_DIR "${_ossl_prefix}/{- unixify($OpenSSL::safe::installdata::LIBDIR_REL_PREFIX, 1); -}/{- unixify($OpenSSL::safe::installdata::MODULESDIR_REL_LIBDIR, 1); -}")
+-set(OPENSSL_RUNTIME_DIR "${_ossl_prefix}/{- unixify($OpenSSL::safe::installdata::BINDIR_REL_PREFIX, 1); -}")
++set(OPENSSL_LIBRARY_DIR "${_ossl_prefix}/{- unixify($OpenSSL::safe::installdata::LIBDIR_REL_PREFIX[0], 1); -}")
++set(OPENSSL_INCLUDE_DIR{- $OUT = '';
++                          $OUT .= ' "${_ossl_prefix}/' . $_ . '"'
++                              foreach (@OpenSSL::safe::installdata::INCLUDEDIR_REL_PREFIX); -})
++set(OPENSSL_ENGINES_DIR "${_ossl_prefix}/{- unixify($OpenSSL::safe::installdata::LIBDIR_REL_PREFIX[0], 1); -}/{- unixify($OpenSSL::safe::installdata::ENGINESDIR_REL_LIBDIR[0], 1); -}")
++set(OPENSSL_MODULES_DIR "${_ossl_prefix}/{- unixify($OpenSSL::safe::installdata::LIBDIR_REL_PREFIX[0], 1); -}/{- unixify($OpenSSL::safe::installdata::MODULESDIR_REL_LIBDIR[0], 1); -}")
++set(OPENSSL_RUNTIME_DIR "${_ossl_prefix}/{- unixify($OpenSSL::safe::installdata::BINDIR_REL_PREFIX[0], 1); -}")
+ {- output_off() if $disabled{uplink}; "" -}
+-set(OPENSSL_APPLINK_SOURCE "${_ossl_prefix}/{- unixify($OpenSSL::safe::installdata::APPLINKDIR_REL_PREFIX, 1); -}/applink.c")
++set(OPENSSL_APPLINK_SOURCE "${_ossl_prefix}/{- unixify($OpenSSL::safe::installdata::APPLINKDIR_REL_PREFIX[0], 1); -}/applink.c")
+ {- output_on() if $disabled{uplink}; "" -}
+ set(OPENSSL_PROGRAM "${OPENSSL_RUNTIME_DIR}/{- platform->bin('openssl') -}")
+ 
+diff --git a/exporters/pkg-config/libcrypto.pc.in b/exporters/pkg-config/libcrypto.pc.in
+index fbc8ea4c79..f225bd6d22 100644
+--- a/exporters/pkg-config/libcrypto.pc.in
++++ b/exporters/pkg-config/libcrypto.pc.in
+@@ -1,15 +1,22 @@
+-prefix={- $OpenSSL::safe::installdata::PREFIX -}
++prefix={- $OpenSSL::safe::installdata::PREFIX[0] -}
+ exec_prefix=${prefix}
+-libdir={- $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX
+-          ? '${exec_prefix}/' . $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX
+-          : $OpenSSL::safe::installdata::libdir -}
+-includedir=${prefix}/{- $OpenSSL::safe::installdata::INCLUDEDIR_REL_PREFIX -}
+-enginesdir=${libdir}/{- $OpenSSL::safe::installdata::ENGINESDIR_REL_LIBDIR -}
+-modulesdir=${libdir}/{- $OpenSSL::safe::installdata::MODULESDIR_REL_LIBDIR -}
++libdir={- $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX[0]
++          ? '${exec_prefix}/' . $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX[0]
++          : $OpenSSL::safe::installdata::libdir[0] -}
++includedir={- $OUT = '';
++              $OUT .= '${prefix}/' . $_ . ' '
++                  foreach (@OpenSSL::safe::installdata::INCLUDEDIR_REL_PREFIX); -}
++enginesdir=${libdir}/{- $OpenSSL::safe::installdata::ENGINESDIR_REL_LIBDIR[0] -}
++modulesdir=${libdir}/{- $OpenSSL::safe::installdata::MODULESDIR_REL_LIBDIR[0] -}
+ 
+ Name: OpenSSL-libcrypto
+ Description: OpenSSL cryptography library
+ Version: {- $OpenSSL::safe::installdata::VERSION -}
+ Libs: -L${libdir} -lcrypto
+ Libs.private: {- join(' ', @OpenSSL::safe::installdata::LDLIBS) -}
+-Cflags: -I${includedir}
++Cflags:{- $OUT = ' -I${includedir}';
++          if (scalar @OpenSSL::safe::installdata::INCLUDEDIR_REL_PREFIX > 1) {
++              $OUT = '';
++              $OUT .= ' -I${prefix}/' . $_ . ' '
++                  foreach (@OpenSSL::safe::installdata::INCLUDEDIR_REL_PREFIX);
++          } -}
+diff --git a/exporters/pkg-config/libssl.pc.in b/exporters/pkg-config/libssl.pc.in
+index 963538807b..80c91ec034 100644
+--- a/exporters/pkg-config/libssl.pc.in
++++ b/exporters/pkg-config/libssl.pc.in
+@@ -3,11 +3,18 @@ exec_prefix=${prefix}
+ libdir={- $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX
+           ? '${exec_prefix}/' . $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX
+           : $OpenSSL::safe::installdata::libdir -}
+-includedir=${prefix}/{- $OpenSSL::safe::installdata::INCLUDEDIR_REL_PREFIX -}
++includedir={- $OUT = '';
++              $OUT .= '${prefix}/' . $_ . ' '
++                  foreach (@OpenSSL::safe::installdata::INCLUDEDIR_REL_PREFIX); -}
+ 
+ Name: OpenSSL-libssl
+ Description: Secure Sockets Layer and cryptography libraries
+ Version: {- $OpenSSL::safe::installdata::VERSION -}
+ Requires.private: libcrypto
+ Libs: -L${libdir} -lssl
+-Cflags: -I${includedir}
++Cflags:{- $OUT = ' -I${includedir}';
++          if (scalar @OpenSSL::safe::installdata::INCLUDEDIR_REL_PREFIX > 1) {
++              $OUT = '';
++              $OUT .= ' -I${prefix}/' . $_ . ' '
++                  foreach (@OpenSSL::safe::installdata::INCLUDEDIR_REL_PREFIX);
++          } -}
+diff --git a/util/mkinstallvars.pl b/util/mkinstallvars.pl
+index e2b7d9d083..52a3d607bd 100644
+--- a/util/mkinstallvars.pl
++++ b/util/mkinstallvars.pl
+@@ -32,10 +32,11 @@ foreach (@others) { $all{$_} = 1 }
+ print STDERR "DEBUG: all keys: ", join(", ", sort keys %all), "\n";
+ 
+ my %keys = ();
++my %values = ();
+ foreach (@ARGV) {
+     (my $k, my $v) = m|^([^=]*)=(.*)$|;
+     $keys{$k} = 1;
+-    $ENV{$k} = $v;
++    push @{$values{$k}}, $v;
+ }
+ 
+ # warn if there are missing values, and also if there are unexpected values
+@@ -49,11 +50,12 @@ foreach my $k (sort keys %keys) {
+ # This shouldn't be needed, but just in case we get relative paths that
+ # should be absolute, make sure they actually are.
+ foreach my $k (@absolutes) {
+-    my $v = $ENV{$k} || '.';
+-    print STDERR "DEBUG: $k = $v => ";
+-    $v = File::Spec->rel2abs($v) if $v;
+-    $ENV{$k} = $v;
+-    print STDERR "$k = $ENV{$k}\n";
++    my $v = $values{$k} || [ '.' ];
++    die "Can't have more than one $k\n" if scalar @$v > 1;
++    print STDERR "DEBUG: $k = $v->[0] => ";
++    $v = [ map { File::Spec->rel2abs($_) } @$v ];
++    $values{$k} = $v;
++    print STDERR "$k = $v->[0]\n";
+ }
+ 
+ # Absolute paths for the subdir variables are computed.  This provides
+@@ -66,18 +68,31 @@ foreach my $k (@absolutes) {
+ foreach my $pair (@subdirs) {
+     my ($var, $subdir_vars) = @$pair;
+     foreach my $k (@$subdir_vars) {
+-        my $v = $ENV{$k} || '.';
+-        print STDERR "DEBUG: $k = $v => ";
+-        if (File::Spec->file_name_is_absolute($v)) {
+-            my $kr = "${k}_REL_${var}";
+-            $ENV{$kr} = File::Spec->abs2rel($v, $ENV{$var});
+-            print STDERR "$kr = $ENV{$kr}\n";
+-        } else {
+-            my $kr = "${k}_REL_${var}";
+-            $ENV{$kr} = $v;
+-            $ENV{$k} = File::Spec->rel2abs($v, $ENV{$var});
+-            print STDERR "$k = $ENV{$k} ,  $kr = $v\n";
++        my $kr = "${k}_REL_${var}";
++        my $v2 = $values{$k} || [ '.' ];
++        $values{$k} = [];       # We're rebuilding it
++        print STDERR "DEBUG: $k = ",
++            (scalar @$v2 > 1 ? "[ " . join(", ", @$v2) . " ]" : $v2->[0]),
++            " => ";
++        foreach my $v (@$v2) {
++            if (File::Spec->file_name_is_absolute($v)) {
++                push @{$values{$k}}, $v;
++                push @{$values{$kr}},
++                    File::Spec->abs2rel($v, $values{$var}->[0]);
++            } else {
++                push @{$values{$kr}}, $v;
++                push @{$values{$k}},
++                    File::Spec->rel2abs($v, $values{$var}->[0]);
++            }
+         }
++        print STDERR join(", ",
++                          map {
++                              my $v = $values{$_};
++                              "$_ = " . (scalar @$v > 1
++                                         ? "[ " . join(", ", @$v) . " ]"
++                                         : $v->[0]);
++                          } ($k, $kr)),
++            "\n";
+     }
+ }
+ 
+@@ -92,13 +107,13 @@ our \@EXPORT = qw(
+ _____
+ 
+ foreach my $k (@absolutes) {
+-    print "    \$$k\n";
++    print "    \@$k\n";
+ }
+ foreach my $pair (@subdirs) {
+     my ($var, $subdir_vars) = @$pair;
+     foreach my $k (@$subdir_vars) {
+         my $k2 = "${k}_REL_${var}";
+-        print "    \$$k \$$k2\n";
++        print "    \@$k \@$k2\n";
+     }
+ }
+ 
+@@ -109,24 +124,30 @@ print <<_____;
+ _____
+ 
+ foreach my $k (@absolutes) {
+-    print "our \$$k" . ' ' x (27 - length($k)) . "= '$ENV{$k}';\n";
++    print "our \@$k" . ' ' x (27 - length($k)) . "= ( '",
++        join("', '", @{$values{$k}}),
++        "' );\n";
+ }
+ foreach my $pair (@subdirs) {
+     my ($var, $subdir_vars) = @$pair;
+     foreach my $k (@$subdir_vars) {
+         my $k2 = "${k}_REL_${var}";
+-        print "our \$$k" . ' ' x (27 - length($k)) . "= '$ENV{$k}';\n";
+-        print "our \$$k2" . ' ' x (27 - length($k2)) . "= '$ENV{$k2}';\n";
++        print "our \@$k" . ' ' x (27 - length($k)) . "= ( '",
++            join("', '", @{$values{$k}}),
++            "' );\n";
++        print "our \@$k2" . ' ' x (27 - length($k2)) . "= ( '",
++            join("', '", @{$values{$k2}}),
++            "' );\n";
+     }
+ }
+ 
+ print <<_____;
+-our \$VERSION                    = '$ENV{VERSION}';
++our \$VERSION                    = '$values{VERSION}->[0]';
+ our \@LDLIBS                     =
+     # Unix and Windows use space separation, VMS uses comma separation
+     \$^O eq 'VMS'
+-    ? split(/ *, */, '$ENV{LDLIBS}')
+-    : split(/ +/, '$ENV{LDLIBS}');
++    ? split(/ *, */, '$values{LDLIBS}->[0]')
++    : split(/ +/, '$values{LDLIBS}->[0]');
+ 
+ 1;
+ _____
+-- 
+2.39.2
+

--- a/recipes/libs/openssl/0008-exporters-for-pkg-config-align-with-the-changes-for-.patch
+++ b/recipes/libs/openssl/0008-exporters-for-pkg-config-align-with-the-changes-for-.patch
@@ -1,0 +1,94 @@
+From 5673de461ae4b5a81f7ecd38103f3467585912bc Mon Sep 17 00:00:00 2001
+From: Richard Levitte <levitte@openssl.org>
+Date: Wed, 28 Aug 2024 18:52:39 +0200
+Subject: [PATCH] exporters for pkg-config: align with the changes for CMake
+
+The latest CMake exporter changes reworked the the variables in builddata.pm
+and installdata.pm.  Unfortunately, the pkg-config exporter templates were
+forgotten in that effort.
+
+Fixes #25299
+
+Reviewed-by: Matt Caswell <matt@openssl.org>
+Reviewed-by: Neil Horman <nhorman@openssl.org>
+(Merged from https://github.com/openssl/openssl/pull/25308)
+
+(cherry picked from commit 15b748496faeebb3b6d8021049bccc93903ee322)
+---
+ exporters/pkg-config/libcrypto.pc.in | 11 ++++++++---
+ exporters/pkg-config/libssl.pc.in    | 13 +++++++++----
+ exporters/pkg-config/openssl.pc.in   | 17 ++++++++++++-----
+ 3 files changed, 29 insertions(+), 12 deletions(-)
+
+diff --git a/exporters/pkg-config/libcrypto.pc.in b/exporters/pkg-config/libcrypto.pc.in
+index f225bd6d22..3d56e97418 100644
+--- a/exporters/pkg-config/libcrypto.pc.in
++++ b/exporters/pkg-config/libcrypto.pc.in
+@@ -1,8 +1,13 @@
+ prefix={- $OpenSSL::safe::installdata::PREFIX[0] -}
+ exec_prefix=${prefix}
+-libdir={- $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX[0]
+-          ? '${exec_prefix}/' . $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX[0]
+-          : $OpenSSL::safe::installdata::libdir[0] -}
++libdir={- if (defined $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX[0]) {
++              my $x = '';
++              $x = '/' . $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX[0]
++                  if $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX[0];
++              '${exec_prefix}' . $x;
++          } else {
++              $OpenSSL::safe::installdata::libdir[0];
++          } -}
+ includedir={- $OUT = '';
+               $OUT .= '${prefix}/' . $_ . ' '
+                   foreach (@OpenSSL::safe::installdata::INCLUDEDIR_REL_PREFIX); -}
+diff --git a/exporters/pkg-config/libssl.pc.in b/exporters/pkg-config/libssl.pc.in
+index 80c91ec034..162db65c99 100644
+--- a/exporters/pkg-config/libssl.pc.in
++++ b/exporters/pkg-config/libssl.pc.in
+@@ -1,8 +1,13 @@
+-prefix={- $OpenSSL::safe::installdata::PREFIX -}
++prefix={- $OpenSSL::safe::installdata::PREFIX[0] -}
+ exec_prefix=${prefix}
+-libdir={- $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX
+-          ? '${exec_prefix}/' . $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX
+-          : $OpenSSL::safe::installdata::libdir -}
++libdir={- if (defined $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX[0]) {
++              my $x = '';
++              $x = '/' . $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX[0]
++                  if $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX[0];
++              '${exec_prefix}' . $x;
++          } else {
++              $OpenSSL::safe::installdata::libdir[0];
++          } -}
+ includedir={- $OUT = '';
+               $OUT .= '${prefix}/' . $_ . ' '
+                   foreach (@OpenSSL::safe::installdata::INCLUDEDIR_REL_PREFIX); -}
+diff --git a/exporters/pkg-config/openssl.pc.in b/exporters/pkg-config/openssl.pc.in
+index 225bef9e23..73eb8e73c2 100644
+--- a/exporters/pkg-config/openssl.pc.in
++++ b/exporters/pkg-config/openssl.pc.in
+@@ -1,9 +1,16 @@
+-prefix={- $OpenSSL::safe::installdata::PREFIX -}
++prefix={- $OpenSSL::safe::installdata::PREFIX[0] -}
+ exec_prefix=${prefix}
+-libdir={- $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX
+-          ? '${exec_prefix}/' . $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX
+-          : $OpenSSL::safe::installdata::libdir -}
+-includedir=${prefix}/{- $OpenSSL::safe::installdata::INCLUDEDIR_REL_PREFIX -}
++libdir={- if (defined $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX[0]) {
++              my $x = '';
++              $x = '/' . $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX[0]
++                  if $OpenSSL::safe::installdata::LIBDIR_REL_PREFIX[0];
++              '${exec_prefix}' . $x;
++          } else {
++              $OpenSSL::safe::installdata::libdir[0];
++          } -}
++includedir={- $OUT = '';
++              $OUT .= '${prefix}/' . $_ . ' '
++                  foreach (@OpenSSL::safe::installdata::INCLUDEDIR_REL_PREFIX); -}
+ 
+ Name: OpenSSL
+ Description: Secure Sockets Layer and cryptography libraries and tools
+-- 
+2.39.2
+


### PR DESCRIPTION
OpenSSL 3.3 introduced a regression that caused the pkg-config files to not be relocatable any more. Cherry pick the fixes from upstream.

See https://github.com/openssl/openssl/issues/24298.