### PR TITLE
Add /usr/share/pkgconfig to PKG_CONFIG search path

### DIFF
--- a/classes/install.yaml
+++ b/classes/install.yaml
@@ -112,6 +112,7 @@ packageSetup: |
             "/usr/lib/*.lib" \
             ${INSTALL_SHARED:+"/usr/lib/*.so*"} \
             "/usr/lib/pkgconfig/***" \
+            "/usr/share/pkgconfig/***" \
             "/usr/lib/cmake/***" \
             ${INSTALL_SHARED:+"/usr/bin/" "/usr/bin/*.dll"} \
             "!*"
@@ -165,6 +166,7 @@ packageSetup: |
             "!/usr/lib/*.a" "!/usr/lib/*.so*" \
             "!/usr/lib/*.lib" "!/usr/bin/*.dll" "!/usr/bin/*.pdb" \
             "!/usr/lib/pkgconfig" \
+            "!/usr/share/pkgconfig" \
             "!/usr/lib/cmake"
         installStripAll .
     }

--- a/classes/pkg-config.yaml
+++ b/classes/pkg-config.yaml
@@ -1,5 +1,7 @@
 buildToolsWeak: [pkg-config]
 buildSetup: |
+    # some tools use the env var only; make sure it points to the executable
+    export PKG_CONFIG="${BOB_TOOL_PATHS[pkg-config]}/pkg-config"
     # make sure to not search any system paths
     export PKG_CONFIG_DIR=
 

--- a/classes/pkg-config.yaml
+++ b/classes/pkg-config.yaml
@@ -9,4 +9,7 @@ buildSetup: |
         if [[ -d "$i/usr/lib/pkgconfig" ]] ; then
             PKG_CONFIG_LIBDIR="${PKG_CONFIG_LIBDIR:+${PKG_CONFIG_LIBDIR}:}$i/usr/lib/pkgconfig"
         fi
+        if [[ -d "$i/usr/share/pkgconfig" ]] ; then
+            PKG_CONFIG_LIBDIR="${PKG_CONFIG_LIBDIR:+${PKG_CONFIG_LIBDIR}:}$i/usr/share/pkgconfig"
+        fi
     done


### PR DESCRIPTION
Some packages install their pc file(s) into /usr/share/pkgconfig. Make sure they are installed and useable.