### PR TITLE
core/coreutils: Pick uclibc compatibility patch + uclibc-mbszero

### DIFF
--- a/recipes/core/coreutils.yaml
+++ b/recipes/core/coreutils.yaml
@@ -1,4 +1,4 @@
-inherit: [autotools]
+inherit: [autotools, patch]
 
 metaEnvironment:
     PKG_VERSION: "9.5"
@@ -14,6 +14,10 @@ checkoutSCM:
     url: ${GNU_MIRROR}/coreutils/coreutils-${PKG_VERSION}.tar.xz
     digestSHA256: "cd328edeac92f6a665de9f323c93b712af1858bc2e0d88f3f7100469470a1b8a"
     stripComponents: 1
+
+checkoutDeterministic: True
+checkoutScript: |
+      patchApplySeries $<@coreutils/*.patch@>
 
 buildScript: |
     autotoolsBuild $1 \

--- a/recipes/core/coreutils/0001-mcel-port-to-uClibc-ng.patch
+++ b/recipes/core/coreutils/0001-mcel-port-to-uClibc-ng.patch
@@ -1,0 +1,32 @@
+From 9765bc796b3e6ceaa7a10ba07c9c2f1e272a4249 Mon Sep 17 00:00:00 2001
+From: Paul Eggert <eggert@cs.ucla.edu>
+Date: Wed, 21 Aug 2024 23:00:38 -0700
+Subject: [PATCH 01/32] mcel: port to uClibc-ng
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Problem reported by Waldemar Brodkorb in:
+https://lists.gnu.org/r/bug-gnulib/2024-08/msg00130.html
+* lib/mcel.h (mcel_scan): Don’t treat uClibc-ng like glibc.
+---
+ lib/mcel.h | 3 ++-
+ 2 files changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/lib/mcel.h b/lib/mcel.h
+index 7d92d24601..d9f8385155 100644
+--- a/lib/mcel.h
++++ b/lib/mcel.h
+@@ -226,7 +226,8 @@ mcel_scan (char const *p, char const *lim)
+ 
+   /* An initial mbstate_t; initialization optimized for some platforms.
+      For details about these and other platforms, see wchar.in.h.  */
+-#if defined __GLIBC__ && 2 < __GLIBC__ + (2 <= __GLIBC_MINOR__)
++#if (defined __GLIBC__ && 2 < __GLIBC__ + (2 <= __GLIBC_MINOR__) \
++     && !defined __UCLIBC__)
+   /* Although only a trivial optimization, it's worth it for GNU.  */
+   mbstate_t mbs; mbs.__count = 0;
+ #elif (defined __FreeBSD__ || defined __DragonFly__ || defined __OpenBSD__ \
+-- 
+2.45.2
+

--- a/recipes/core/coreutils/0002-gcc14-uclibc-mbszero-fix.patch
+++ b/recipes/core/coreutils/0002-gcc14-uclibc-mbszero-fix.patch
@@ -1,0 +1,33 @@
+diff -urN a/src/df.c b/src/df.c
+--- a/src/df.c	2024-01-01 14:27:23.000000000 +0100
++++ b/src/df.c	2024-09-16 11:19:31.761134576 +0200
+@@ -23,6 +23,7 @@
+ #include <sys/types.h>
+ #include <getopt.h>
+ #include <c-ctype.h>
++#include <wchar.h>
+ #include <uchar.h>
+ 
+ #include "system.h"
+diff -urN a/src/ls.c b/src/ls.c
+--- a/src/ls.c	2024-03-26 19:57:27.000000000 +0100
++++ b/src/ls.c	2024-09-16 11:19:49.949082419 +0200
+@@ -56,6 +56,7 @@
+ #include <getopt.h>
+ #include <signal.h>
+ #include <selinux/selinux.h>
++#include <wchar.h>
+ #include <uchar.h>
+ 
+ #if HAVE_LANGINFO_CODESET
+diff -urN a/src/wc.c b/src/wc.c
+--- a/src/wc.c	2024-02-26 18:33:02.000000000 +0100
++++ b/src/wc.c	2024-09-16 11:20:46.212921888 +0200
+@@ -23,6 +23,7 @@
+ #include <stdio.h>
+ #include <getopt.h>
+ #include <sys/types.h>
++#include <wchar.h>
+ #include <uchar.h>
+ 
+ #include <argmatch.h>


### PR DESCRIPTION
Pick the change from gnulib making coreutils compile with uclibc. Plus add some header include fixes for uclibc that trigger with gcc14. Might need to be discussed.