### PR TITLE
sandbox: don't remove the code page converting libs

### DIFF
--- a/classes/sandbox.yaml
+++ b/classes/sandbox.yaml
@@ -41,8 +41,8 @@ buildScript: |
     find . -type d -name .debug | xargs /bin/rm -rf
     find . -not -path ./toolchain/sysroots -executable -type f -exec ${CROSS_COMPILE}strip -g {} \;
 
-    # remove locales and codepages
-    rm -rf usr/share/locale usr/lib/gconv
+    # remove locales
+    rm -rf usr/share/locale
 
     # Create an empty resolv.conf. The host version is mounted over this one
     # when entering the sandbox.


### PR DESCRIPTION
Actually some tools require code page converting functionality when used as host tools. One of those are the mtools which try to convert to some fat specific code pages and fail when the gconv libraries are not there.