### PR TITLE
core::util-linux: bump to v2.40.2

### DIFF
--- a/classes/basement/rootrecipe.yaml
+++ b/classes/basement/rootrecipe.yaml
@@ -71,7 +71,7 @@ depends:
         - name: devel::cmake            # Overwrite "cmake" tool with properly
           use: [tools]                  # built one.
           forward: True
-        - name: core::util-linux-tools
+        - name: core::util-linux
           use: [tools]
           forward: True
 

--- a/recipes/core/util-linux.yaml
+++ b/recipes/core/util-linux.yaml
@@ -2,7 +2,7 @@ inherit: [autotools]
 
 metaEnvironment:
     PKG_VERSION_MAJOR: "2.40"
-    PKG_VERSION: "2.40.1"
+    PKG_VERSION: "2.40.2"
 
 depends:
     - libs::ncurses-dev
@@ -16,7 +16,7 @@ depends:
 checkoutSCM:
     scm: url
     url: ${KERNEL_MIRROR}/linux/utils/util-linux/v${PKG_VERSION_MAJOR}/util-linux-${PKG_VERSION}.tar.xz
-    digestSHA256: "59e676aa53ccb44b6c39f0ffe01a8fa274891c91bef1474752fad92461def24f"
+    digestSHA256: "d78b37a66f5922d70edf3bdfb01a6b33d34ed3c3cafd6628203b2a2b67c8e8b3"
     stripComponents: 1
 
 buildScript: |

--- a/recipes/core/util-linux.yaml
+++ b/recipes/core/util-linux.yaml
@@ -34,14 +34,19 @@ buildScript: |
         sbindir=/usr/sbin
 
 multiPackage:
-    dev:
-        packageScript: autotoolsPackageDev
-
-    tgt:
-        packageScript: autotoolsPackageTgt
-        provideDeps: [ "*-tgt" ]
-
-    tools:
+    "":
+        depends:
+            - name: core::util-linux-tgt
+              use: []
         packageScript: autotoolsPackageBin
+        provideDeps: [ "*-tgt" ]
         provideTools:
             util-linux: "usr/sbin"
+
+    dev:
+        packageScript: autotoolsPackageDev
+        provideDeps: [ "*-dev" ]
+
+    tgt:
+        packageScript: autotoolsPackageLib
+        provideDeps: [ "*-tgt" ]

--- a/recipes/devel/bootstrap-sandbox.yaml
+++ b/recipes/devel/bootstrap-sandbox.yaml
@@ -55,7 +55,7 @@ depends:
 
     # stuff that goes into the sandbox image
     - core::coreutils
-    - core::util-linux-tgt
+    - core::util-linux
     - devel::diffutils
     - devel::m4
     - devel::patch

--- a/recipes/devel/sandbox.yaml
+++ b/recipes/devel/sandbox.yaml
@@ -63,7 +63,7 @@ depends:
         forward: True
 
     - core::coreutils
-    - core::util-linux-tgt
+    - core::util-linux
     - devel::diffutils
     - devel::fakeroot
     - devel::git


### PR DESCRIPTION
Add a new generic bin target and install only libs in *-tgt. Some apps depend on the libs and don't necessarily need the executables as well. Also there was a provideDeps missing.