### PR TITLE
Addendum to 32e9ecf

### DIFF
--- a/classes/install.yaml
+++ b/classes/install.yaml
@@ -113,8 +113,9 @@ packageSetup: |
             "/usr/lib/*.lib" \
             ${INSTALL_SHARED:+"/usr/lib/*.so*"} \
             "/usr/lib/pkgconfig/***" \
-            "/usr/share/pkgconfig/***" \
             "/usr/lib/cmake/***" \
+            "/usr/share/" \
+            "/usr/share/pkgconfig/***" \
             ${INSTALL_SHARED:+"/usr/bin/" "/usr/bin/*.dll"} \
             "!*"
 


### PR DESCRIPTION
rsync doesn't consider /usr/share/pkgconfig if not also /usr/share is specified.