### PR TITLE
add pre-commit

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,2 @@
+[codespell]
+skip = */config.guess,*.diff,*.patch

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+exclude: |
+    (?x)^(
+      .*.patch|
+      .*.diff
+    )$
+
+repos:
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v5.0.0
+      hooks:
+        - id: check-yaml
+          args: ["--unsafe"]
+          # unsafe is needed to avoid:
+          # "could not determine a constructor for the tag '!expr'"
+        - id: end-of-file-fixer
+        - id: trailing-whitespace
+
+    - repo: https://github.com/adrienverge/yamllint.git
+      rev: v1.35.1
+      hooks:
+        - id: yamllint
+    - repo: https://github.com/codespell-project/codespell
+      rev: v2.3.0
+      hooks:
+        - id: codespell

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,54 @@
+---
+
+yaml-files:
+    - '*.yaml'
+    - '.yamllint'
+
+rules:
+    anchors:
+        forbid-undeclared-aliases: true
+        forbid-duplicated-anchors: true
+        forbid-unused-anchors: true
+    braces:
+        forbid: non-empty
+    brackets:
+        forbid: false
+        min-spaces-inside: -1
+        max-spaces-inside: -1
+        min-spaces-inside-empty: -1
+        max-spaces-inside-empty: -1
+    colons:
+        max-spaces-before: 0
+        max-spaces-after: -1
+    commas: enable
+    comments:
+        require-starting-space: true
+        ignore-shebangs: true
+        min-spaces-from-content: 1
+    comments-indentation: enable
+    document-end: disable
+    document-start: disable
+    empty-lines:
+        max: 1
+        max-start: 0
+        max-end: 0
+    empty-values: disable
+    float-values: disable
+    hyphens: enable
+    indentation:
+        spaces: 4
+        indent-sequences: consistent
+        level: warning
+    key-duplicates:
+        forbid-duplicated-merge-keys: true
+    key-ordering: disable
+    line-length:
+        max: 120
+        # level: warning
+    new-line-at-end-of-file: enable
+    new-lines: enable
+    octal-values: enable
+    quoted-strings: disable
+    trailing-spaces: enable
+    truthy:
+        allowed-values: ['true', 'True', 'false', 'False']

--- a/classes/autotools-noarch.yaml
+++ b/classes/autotools-noarch.yaml
@@ -77,4 +77,3 @@ packageSetup: |
     {
         installPackageTgt "${1:-${_AUTOTOOLS_NOARCH_BUILD_PATH}}/install/" "${@:2}"
     }
-

--- a/classes/basement/bits/libs.yaml
+++ b/classes/basement/bits/libs.yaml
@@ -19,7 +19,7 @@ buildSetup: &commonScript |
     #
     # By default, shared libraries are built when cross-compiling and static
     # libraries on host builds (including the bob_compat cross-toolchain).
-    # This can be overridded by setting BASEMENT_LIBS to "static", "shared" or
+    # This can be overridden by setting BASEMENT_LIBS to "static", "shared" or
     # "both".
     basementBitsLibraryType()
     {

--- a/classes/cpackage.yaml
+++ b/classes/cpackage.yaml
@@ -72,4 +72,3 @@ buildSetup: |
 
     [ -z "${CPPFLAGS:+true}" ] || export CPPFLAGS
     [ -z "${LDFLAGS:+true}" ] || export LDFLAGS
-

--- a/classes/install.yaml
+++ b/classes/install.yaml
@@ -72,7 +72,7 @@ packageSetup: |
         stripAll "$1"
     }
 
-    # Copy files matching the given patterns, 
+    # Copy files matching the given patterns,
     installCopy()
     {
         declare -a OPTS=(
@@ -140,7 +140,7 @@ packageSetup: |
             installCopy "$@" /usr/ \
                 /usr/bin/ "/usr/bin/*.dll" "/usr/bin/*.pdb" \
                 "!*"
-            # Be a bit more carefull for UNIX shared objects. Only copy real
+            # Be a bit more careful for UNIX shared objects. Only copy real
             # files. If the SONAME differs from the file name, create the
             # symlink too.
             local d f

--- a/classes/libtool.yaml
+++ b/classes/libtool.yaml
@@ -30,4 +30,3 @@ checkoutSetup: |
     if [[ ${APPLY_LIBTOOL_PATCH:-yes} != no ]] ; then
         libtoolApply
     fi
-

--- a/classes/msbuild.yaml
+++ b/classes/msbuild.yaml
@@ -3,4 +3,3 @@ buildTools: [msbuild]
 buildVarsWeak: [MSB_PATH]
 buildSetup: |
     ${MSB_PATH:+export PATH="$PATH:$MSB_PATH"}
-

--- a/classes/python3-cext-pkg.yaml
+++ b/classes/python3-cext-pkg.yaml
@@ -10,7 +10,8 @@ buildTools: [target-toolchain]
 buildSetup: |
     if cpackageCrossCompiling ; then
         export _PYTHON_HOST_PLATFORM="linux-$ARCH"
-        export _PYTHON_SYSCONFIGDATA_NAME=$(basename "${BOB_DEP_PATHS[python::python3-dev]}"/usr/lib/python3.*/_sysconfigdata_*.py .py)
+        export _PYTHON_SYSCONFIGDATA_NAME=$(basename \
+            "${BOB_DEP_PATHS[python::python3-dev]}"/usr/lib/python3.*/_sysconfigdata_*.py .py)
     fi
 
     python3CExtInstallPip()

--- a/classes/python3-usr.yaml
+++ b/classes/python3-usr.yaml
@@ -3,7 +3,8 @@ checkoutSetup: &ref |
 
     if command -v python3 2>&1 >/dev/null; then
         PYTHONPATH=
-        PYTHON3_DESTLIB="$(python3 -c "import sysconfig; print(sysconfig.get_config_var('DESTLIB') or '/usr/lib/python3')")"
+        PYTHON3_DESTLIB="$(python3 -c \
+            "import sysconfig; print(sysconfig.get_config_var('DESTLIB') or '/usr/lib/python3')")"
         for i in "${!BOB_ALL_PATHS[@]}" ; do
             for j in "" "lib-dynload" "site-packages" "dist-packages" ; do
                 l="${BOB_ALL_PATHS[$i]}${PYTHON3_DESTLIB}${j:+/$j}"

--- a/classes/sandbox-toolchain.yaml
+++ b/classes/sandbox-toolchain.yaml
@@ -32,7 +32,9 @@ packageScript: |
     # Create a wrapper scripts that prefer the right executable in /toolchain
     # and (if we are outside of a sandbox) fall back to globally installed
     # versions.
-    for i in addr2line ar as c++ c++filt cpp elfedit g++ gcc gcov gdb gprof ld nm objcopy objdump ranlib readelf size strings strip ; do
+    TOOLS=(addr2line ar as c++ c++filt cpp elfedit g++ gcc gcov gdb)
+    TOOLS+=(gprof ld nm objcopy objdump ranlib readelf size strings strip)
+    for i in  ${TOOLS[@]}; do
         ln -sf /toolchain/bin/$i
         cat >${SANDBOX_AUTOCONF_BUILD}-$i <<EOF
     #!/bin/bash

--- a/classes/sandbox.yaml
+++ b/classes/sandbox.yaml
@@ -66,4 +66,3 @@ provideSandbox:
     paths: ["/usr/bin"]
     mount:
         - "/etc/resolv.conf"
-

--- a/classes/strip.yaml
+++ b/classes/strip.yaml
@@ -13,7 +13,7 @@ packageSetup: |
 
             local dir="${1%/*}/.debug" file="${1##*/}"
 
-            # Split off the debug symbols into separete file. Doesn't need to
+            # Split off the debug symbols into separate file. Doesn't need to
             # stay executable...
             mkdir -p "$dir"
             $OBJCOPY --only-keep-debug --compress-debug-sections "$1" "${dir}/${file}"

--- a/default.yaml
+++ b/default.yaml
@@ -66,7 +66,7 @@ include:
 # working. If you need ssh access from a checkoutScript too you have to add
 # the lines below to your projects default.yaml.
 whitelist: ["SSH_AGENT_PID", "SSH_AUTH_SOCK"]
-#sandbox:
+# sandbox:
 #    mount:
 #        - [ "\\$HOME/.ssh", "/nonexistent/.ssh"]
 #        - [ "\\$SSH_AUTH_SOCK", "\\$SSH_AUTH_SOCK", [nojenkins, nofail] ]

--- a/recipes/categories.txt
+++ b/recipes/categories.txt
@@ -5,7 +5,7 @@ devel/		-- Development utilities, compilers, development environments, libraries
 graphics/   -- X and other graphically related system libraries
 kernel/		-- Operating System Kernels and related modules.
 libs/		-- Libraries to make other programs work.
-multimedia/ -- Codecs and support utilties for audio, images and video
+multimedia/ -- Codecs and support utilities for audio, images and video
 net/		-- Daemons and clients to connect your system to the world.
 perl/		-- Everything about Perl, an interpreted scripting language.
 python/		-- Everything about Python, an interpreted, interactive object oriented language.

--- a/recipes/devel/binutils.yaml
+++ b/recipes/devel/binutils.yaml
@@ -61,4 +61,3 @@ multiPackage:
                 packageScript: autotoolsPackageDev
             tgt:
                 packageScript: autotoolsPackageTgt
-

--- a/recipes/devel/bison.yaml
+++ b/recipes/devel/bison.yaml
@@ -3,7 +3,7 @@ inherit: [autotools]
 metaEnvironment:
     PKG_VERSION: "3.8.2"
 
-# parallel make sometimes failes in examples/c/reccalc/...
+# parallel make sometimes fails in examples/c/reccalc/...
 jobServer: False
 privateEnvironment:
     MAKE_JOBS: "1"
@@ -30,4 +30,3 @@ packageScript: |
 
 provideTools:
     bison: usr/bin
-

--- a/recipes/devel/bootstrap-sandbox.yaml
+++ b/recipes/devel/bootstrap-sandbox.yaml
@@ -83,4 +83,3 @@ depends:
       depends:
         - devel::binutils
         - devel::gcc-native
-

--- a/recipes/devel/compat/binutils.yaml
+++ b/recipes/devel/compat/binutils.yaml
@@ -41,4 +41,3 @@ packageScript: |
 
 provideTools:
     binutils: usr/bin
-

--- a/recipes/devel/cross-toolchain.yaml
+++ b/recipes/devel/cross-toolchain.yaml
@@ -53,7 +53,7 @@ provideTools:
             STRIP: "${AUTOCONF_TARGET}-strip"
 
             # Host system definition. Note that we do not touch the build
-            # system definiton (AUTOCONF_BUILD) because this is a cross
+            # system definition (AUTOCONF_BUILD) because this is a cross
             # compiling toolchain.
             ARCH: "${ARCH}"
             AUTOCONF_HOST: "${AUTOCONF_TARGET}"

--- a/recipes/devel/diffutils.yaml
+++ b/recipes/devel/diffutils.yaml
@@ -14,5 +14,3 @@ buildScript: |
 
 packageScript: |
     autotoolsPackageTgt
-
-

--- a/recipes/devel/fakeroot.yaml
+++ b/recipes/devel/fakeroot.yaml
@@ -12,7 +12,8 @@ depends:
 
 checkoutSCM:
     scm: url
-    url: https://snapshot.debian.org/archive/debian/20240521T144222Z/pool/main/f/fakeroot/fakeroot_${PKG_VERSION}.orig.tar.gz
+    url: "https://snapshot.debian.org/archive/debian/20240521T144222Z/pool/main/f/fakeroot/\
+          fakeroot_${PKG_VERSION}.orig.tar.gz"
     digestSHA256: 5727f16d8903792588efa7a9f8ef8ce71f8756e746b62e45162e7735662e56bb
     stripComponents: 1
 

--- a/recipes/devel/flex.yaml
+++ b/recipes/devel/flex.yaml
@@ -21,7 +21,7 @@ buildTools: [bison, host-toolchain]
 buildScript: |
     export M4=m4
     autotoolsBuild $1 \
-        --disable-nls 
+        --disable-nls
 
 packageScript: |
     autotoolsPackageTgt

--- a/recipes/devel/gcc.yaml
+++ b/recipes/devel/gcc.yaml
@@ -137,7 +137,7 @@ multiPackage:
                     STRIP: "${AUTOCONF_TARGET}-strip"
 
                     # Host system definition. Note that we do not touch the build
-                    # system definiton (AUTOCONF_BUILD) because this is a cross
+                    # system definition (AUTOCONF_BUILD) because this is a cross
                     # compiling toolchain.
                     ARCH: "${ARCH}"
                     AUTOCONF_HOST: "${AUTOCONF_TARGET}"
@@ -195,7 +195,7 @@ multiPackage:
             - libs::newlib
 
         multiPackage:
-            # Straigtforward cross compiler. This is a regular cross compiler
+            # Straightforward cross compiler. This is a regular cross compiler
             # built by the native host compiler. As such, it is usually not
             # intended to be used directly but to bootstrap the canadian cross
             # compiler below.

--- a/recipes/devel/libtool.yaml
+++ b/recipes/devel/libtool.yaml
@@ -1,4 +1,4 @@
-# Eagerly inherit libtool beause it defines a checkoutScript and will be
+# Eagerly inherit libtool because it defines a checkoutScript and will be
 # inherited by the autotools class anyway. This prevents a separate checkout
 # for the anonymous multiPackage which does not depend on the autotools class.
 inherit: [libtool, patch]

--- a/recipes/devel/libtool.yaml
+++ b/recipes/devel/libtool.yaml
@@ -27,7 +27,15 @@ multiPackage:
         buildVars: [PKG_VERSION]
         buildScript: |
             pkgaux_files="compile config.guess config.sub depcomp install-sh missing ltmain.sh"
-            pkgltdl_files="COPYING.LIB Makefile.am README configure.ac aclocal.m4 Makefile.in config-h.in configure libltdl/lt__alloc.h libltdl/lt__argz_.h libltdl/lt__dirent.h libltdl/lt__glibc.h libltdl/lt__private.h libltdl/lt__strl.h libltdl/lt_dlloader.h libltdl/lt_error.h libltdl/lt_system.h libltdl/slist.h loaders/dld_link.c loaders/dlopen.c loaders/dyld.c loaders/load_add_on.c loaders/loadlibrary.c loaders/preopen.c loaders/shl_load.c lt__alloc.c lt__argz.c lt__dirent.c lt__strl.c lt_dlloader.c lt_error.c ltdl.c ltdl.h ltdl.mk slist.c"
+            pkgltdl_files="COPYING.LIB Makefile.am README configure.ac \
+                aclocal.m4 Makefile.in config-h.in configure libltdl/lt__alloc.h \
+                libltdl/lt__argz_.h libltdl/lt__dirent.h libltdl/lt__glibc.h \
+                libltdl/lt__private.h libltdl/lt__strl.h libltdl/lt_dlloader.h \
+                libltdl/lt_error.h libltdl/lt_system.h libltdl/slist.h \
+                loaders/dld_link.c loaders/dlopen.c loaders/dyld.c \
+                loaders/load_add_on.c loaders/loadlibrary.c loaders/preopen.c \
+                loaders/shl_load.c lt__alloc.c lt__argz.c lt__dirent.c lt__strl.c \
+                lt_dlloader.c lt_error.c ltdl.c ltdl.h ltdl.mk slist.c"
             pkgmacro_files="libtool.m4 ltargz.m4 ltdl.m4 ltoptions.m4 ltsugar.m4 ltversion.m4 lt~obsolete.m4"
 
             mkdir -p usr/bin usr/share/aclocal usr/share/libtool/build-aux

--- a/recipes/devel/m4.yaml
+++ b/recipes/devel/m4.yaml
@@ -14,4 +14,3 @@ buildScript: |
 
 packageScript: |
     autotoolsPackageTgt
-

--- a/recipes/devel/patch.yaml
+++ b/recipes/devel/patch.yaml
@@ -14,4 +14,3 @@ buildScript: |
 
 packageScript: |
     autotoolsPackageTgt
-

--- a/recipes/devel/pkg-config.yaml
+++ b/recipes/devel/pkg-config.yaml
@@ -1,4 +1,4 @@
-# Eagerly inherit libtool beause it defines a checkoutScript and will be
+# Eagerly inherit libtool because it defines a checkoutScript and will be
 # inherited by the autotools class anyway. This prevents a separate checkout
 # for the aclocal multiPackage which does not depend on the autotools class.
 inherit: [libtool, patch]

--- a/recipes/devel/sandbox.yaml
+++ b/recipes/devel/sandbox.yaml
@@ -96,4 +96,3 @@ depends:
       depends:
         - devel::binutils
         - devel::gcc-native
-

--- a/recipes/devel/texinfo.yaml
+++ b/recipes/devel/texinfo.yaml
@@ -15,4 +15,3 @@ buildScript: |
 
 packageScript: |
     autotoolsPackageTgt
-

--- a/recipes/devel/win/vs2019-toolchain.yaml
+++ b/recipes/devel/win/vs2019-toolchain.yaml
@@ -26,8 +26,10 @@ provideTools:
 
 provideVars:
     CPPFLAGS: ""
-    CFLAGS: "-O$(if-then-else,$(eq,${BASEMENT_OPTIMIZE},0),d,${BASEMENT_OPTIMIZE})$(if-then-else,${BASEMENT_DEBUG}, -Zi,) -MD$(if-then-else,${BASEMENT_DEBUG},d,) -W3"
-    CXXFLAGS: "-O$(if-then-else,$(eq,${BASEMENT_OPTIMIZE},0),d,${BASEMENT_OPTIMIZE})$(if-then-else,${BASEMENT_DEBUG}, -Zi,) -MD$(if-then-else,${BASEMENT_DEBUG},d,) -W3"
+    CFLAGS: "-O$(if-then-else,$(eq,${BASEMENT_OPTIMIZE},0),d,${BASEMENT_OPTIMIZE})\
+             $(if-then-else,${BASEMENT_DEBUG}, -Zi,) -MD$(if-then-else,${BASEMENT_DEBUG},d,) -W3"
+    CXXFLAGS: "-O$(if-then-else,$(eq,${BASEMENT_OPTIMIZE},0),d,${BASEMENT_OPTIMIZE})\
+               $(if-then-else,${BASEMENT_DEBUG}, -Zi,) -MD$(if-then-else,${BASEMENT_DEBUG},d,) -W3"
     LDFLAGS: "$(if-then-else,${BASEMENT_DEBUG}, -debug,)"
 
 multiPackage:

--- a/recipes/editors/ed.yaml
+++ b/recipes/editors/ed.yaml
@@ -16,4 +16,3 @@ buildScript: |
 
 packageScript: |
     autotoolsPackageTgt
-

--- a/recipes/libs/expat.yaml
+++ b/recipes/libs/expat.yaml
@@ -17,4 +17,3 @@ multiPackage:
         packageScript: autotoolsPackageDev
     tgt:
         packageScript: autotoolsPackageTgt
-

--- a/recipes/libs/expat.yaml
+++ b/recipes/libs/expat.yaml
@@ -5,7 +5,8 @@ metaEnvironment:
 
 checkoutSCM:
    scm: url
-   url: ${GITHUB_MIRROR}/libexpat/libexpat/releases/download/R_$(subst,".","_",${PKG_VERSION})/expat-${PKG_VERSION}.tar.gz
+   url: "${GITHUB_MIRROR}/libexpat/libexpat/releases/download/\
+         R_$(subst,'.','_',${PKG_VERSION})/expat-${PKG_VERSION}.tar.gz"
    digestSHA256: a00ae8a6b96b63a3910ddc1100b1a7ef50dc26dceb65ced18ded31ab392f132b
    stripComponents: 1
 

--- a/recipes/libs/libcap.yaml
+++ b/recipes/libs/libcap.yaml
@@ -31,4 +31,3 @@ multiPackage:
         packageScript: installPackageDev "$1/install/"
     tgt:
         packageScript: installPackageTgt "$1/install/"
-

--- a/recipes/libs/libffi.yaml
+++ b/recipes/libs/libffi.yaml
@@ -21,4 +21,3 @@ multiPackage:
         packageScript: autotoolsPackageDev
     tgt:
         packageScript: autotoolsPackageTgt
-

--- a/recipes/libs/libuv.yaml
+++ b/recipes/libs/libuv.yaml
@@ -30,4 +30,3 @@ multiPackage:
         packageScript: autotoolsPackageDev
     tgt:
         packageScript: autotoolsPackageTgt
-

--- a/recipes/libs/ncurses.yaml
+++ b/recipes/libs/ncurses.yaml
@@ -74,4 +74,3 @@ multiPackage:
         packageScript: |
             autotoolsPackageTgt
             rm -f usr/bin/*-config
-

--- a/recipes/libs/pcre.yaml
+++ b/recipes/libs/pcre.yaml
@@ -21,7 +21,7 @@ buildScript: |
 
 multiPackage:
     lib-1-dev:
-        # include pcre-config in case other configure scrips need it
+        # include pcre-config in case other configure scripts need it
         packageScript: |
             autotoolsPackageDev $1 \
                 /usr /usr/bin /usr/bin/pcre-config

--- a/recipes/libs/zlib.yaml
+++ b/recipes/libs/zlib.yaml
@@ -50,4 +50,3 @@ multiPackage:
         packageScript: installPackageDev "$1/install/"
     tgt:
         packageScript: installPackageTgt "$1/install/"
-

--- a/recipes/libs/zstd.yaml
+++ b/recipes/libs/zstd.yaml
@@ -26,9 +26,13 @@ buildScript: |
     export LIB_BINDIR=$PWD/build/lib
 
     pushd build
-    makeParallel -C lib $(cpackageLibraryTypeCheck libzstd.a-mt-release lib-mt-release)
-    makeParallel -C programs $(if [[ $(cpackageLibraryType) = static ]] ; then echo zstd-release ; else echo zstd-dll ; fi)
-    makeParallel -C lib install-pc install-includes $(cpackageLibraryTypeCheck install-static install-shared)
+    makeParallel -C lib \
+        $(cpackageLibraryTypeCheck libzstd.a-mt-release lib-mt-release)
+    makeParallel -C programs \
+        $(if [[ $(cpackageLibraryType) = static ]] ; then \
+            echo zstd-release ; else echo zstd-dll ; fi)
+    makeParallel -C lib install-pc install-includes \
+        $(cpackageLibraryTypeCheck install-static install-shared)
     makeParallel -C programs install
     popd
 

--- a/recipes/python/python3.yaml
+++ b/recipes/python/python3.yaml
@@ -112,7 +112,6 @@ multiPackage:
                     ln -sf python3 usr/bin/python
                 provideDeps: [ "*-tgt" ]
 
-
     minimal:
         depends:
            - libs::expat-dev

--- a/recipes/utils/bash.yaml
+++ b/recipes/utils/bash.yaml
@@ -35,7 +35,7 @@ buildScript: |
     export bash_cv_func_sigsetjmp=present
     export bash_cv_printf_a_format=yes
     autotoolsBuild $1 \
-        --with-installed-readline 
+        --with-installed-readline
 
     mkdir -p install/.bob
 
@@ -51,4 +51,3 @@ provideDeps: [ "*-tgt" ]
 
 provideVars:
     BASH_VERSION: "${PKG_VERSION}"
-

--- a/recipes/utils/bzip2.yaml
+++ b/recipes/utils/bzip2.yaml
@@ -23,4 +23,3 @@ buildScript: |
 
 packageScript: |
     installPackageTgt "$1/install/"
-

--- a/recipes/utils/file.yaml
+++ b/recipes/utils/file.yaml
@@ -24,4 +24,3 @@ buildScript: |
 
 packageScript: |
     autotoolsPackageTgt
-

--- a/recipes/utils/findutils.yaml
+++ b/recipes/utils/findutils.yaml
@@ -14,4 +14,3 @@ buildScript: |
 
 packageScript: |
     autotoolsPackageTgt
-

--- a/recipes/utils/gzip.yaml
+++ b/recipes/utils/gzip.yaml
@@ -14,4 +14,3 @@ buildScript: |
 
 packageScript: |
     autotoolsPackageTgt
-

--- a/recipes/utils/rsync.yaml
+++ b/recipes/utils/rsync.yaml
@@ -21,6 +21,5 @@ buildScript: |
        --disable-zstd \
        --disable-lz4
 
-
 packageScript: |
     autotoolsPackageTgt

--- a/recipes/utils/sed.yaml
+++ b/recipes/utils/sed.yaml
@@ -14,4 +14,3 @@ buildScript: |
 
 packageScript: |
     autotoolsPackageTgt
-

--- a/recipes/utils/tar.yaml
+++ b/recipes/utils/tar.yaml
@@ -14,4 +14,3 @@ buildScript: |
 
 packageScript: |
     autotoolsPackageTgt
-

--- a/recipes/utils/unzip.yaml
+++ b/recipes/utils/unzip.yaml
@@ -22,4 +22,3 @@ buildScript: |
 
 packageScript: |
    installPackageTgt "$1/install/"
-


### PR DESCRIPTION
    Add initial pre-commit configuration files. The pre-commit tool can be
    installed using pip:
       pip3 install pre-commit
    
    After that the hook can be activated using:
       pre-commit install
    
    or just run on the modified files
       pre-commit run
    
    ATM the following checks are active:
      - check-yaml
      - end-of-file-fixer
      - trailing-whitespace
      - yamllint
      - codespell
