### PR TITLE
plugins/msbuild: fix SyntaxWarning

### DIFF
--- a/plugins/msbuild.py
+++ b/plugins/msbuild.py
@@ -15,7 +15,7 @@ def msbuild(args, **options):
     try:
         vswargs = (os.path.join(os.environ["ProgramFiles(x86)"],
                                 "Microsoft Visual Studio/Installer/vswhere.exe"),
-                '-find', 'MSBuild\**\Bin\MSBuild.exe',
+                '-find', r'MSBuild\**\Bin\MSBuild.exe',
                 '-latest',
                 '-products', '*',
                 '-requires', 'Microsoft.Component.MSBuild')


### PR DESCRIPTION
Use a raw-string here to avoid

 plugins/msbuild.py:18: SyntaxWarning: invalid escape sequence '\*'
  '-find', 'MSBuild\**\Bin\MSBuild.exe',