### PR TITLE
libs::libc: add openmp-tgt target

### DIFF
--- a/recipes/libs/libc.yaml
+++ b/recipes/libs/libc.yaml
@@ -64,6 +64,13 @@ multiPackage:
                 "libstdc++.so.*" \
                 "!*"
 
+    openmp-tgt:
+        buildScript: |
+            copyFiles /usr/ /usr/lib/ \
+                "!*.py" \
+                "libgomp.so.*" \
+                "!*"
+
     bin:
         depends:
             - use: []


### PR DESCRIPTION
Make it possible to install gcc's libgomp.so into the target. Some applications may use it.