### PR TITLE
classes/cmake: Add L4Re to toolchain

### DIFF
--- a/classes/cmake.yaml
+++ b/classes/cmake.yaml
@@ -47,6 +47,9 @@ buildSetup: |
             *-linux-*)
                 CMAKE_SYSTEM_NAME=Linux
                 ;;
+            *-l4re)
+                CMAKE_SYSTEM_NAME=Linux
+                ;;
             *-msys|*-win32)
                 CMAKE_SYSTEM_NAME=Windows
                 ;;


### PR DESCRIPTION
Recognize "l4re" as a toolchain target, pointing to Linux for the time being.