### PR TITLE
python3-usr: provide sepeate class for checkout usage

### DIFF
--- a/classes/python3-usr.yaml
+++ b/classes/python3-usr.yaml
@@ -1,21 +1,18 @@
-checkoutSetup: &ref |
+buildTools: [python3]
+buildSetup: &ref |
     export PYTHONNOUSERSITE=1
 
-    if command -v python3 2>&1 >/dev/null; then
-        PYTHONPATH=
-        PYTHON3_DESTLIB="$(python3 -c \
-            "import sysconfig; print(sysconfig.get_config_var('DESTLIB') or '/usr/lib/python3')")"
-        for i in "${!BOB_ALL_PATHS[@]}" ; do
-            for j in "" "lib-dynload" "site-packages" "dist-packages" ; do
-                l="${BOB_ALL_PATHS[$i]}${PYTHON3_DESTLIB}${j:+/$j}"
-                if [[ -d "$l" ]] ; then
-                    PYTHONPATH+="${PYTHONPATH:+:}$l"
-                fi
-            done
+    PYTHONPATH=
+    PYTHON3_DESTLIB="$(python3 -c \
+        "import sysconfig; print(sysconfig.get_config_var('DESTLIB') or '/usr/lib/python3')")"
+    for i in "${!BOB_ALL_PATHS[@]}" ; do
+        for j in "" "lib-dynload" "site-packages" "dist-packages" ; do
+            l="${BOB_ALL_PATHS[$i]}${PYTHON3_DESTLIB}${j:+/$j}"
+            if [[ -d "$l" ]] ; then
+                PYTHONPATH+="${PYTHONPATH:+:}$l"
+            fi
         done
-        export PYTHONPATH
-    fi
+    done
+    export PYTHONPATH
 
-buildTools: [python3]
-buildSetup: *ref
 packageSetup: *ref

--- a/classes/python3-usr_checkout.yaml
+++ b/classes/python3-usr_checkout.yaml
@@ -1,0 +1,18 @@
+checkoutTools: [python3]
+checkoutSetup: |
+    export PYTHONNOUSERSITE=1
+
+    if command -v python3 2>&1 >/dev/null; then
+        PYTHONPATH=
+        PYTHON3_DESTLIB="$(python3 -c \
+            "import sysconfig; print(sysconfig.get_config_var('DESTLIB') or '/usr/lib/python3')")"
+        for i in "${!BOB_ALL_PATHS[@]}" ; do
+            for j in "" "lib-dynload" "site-packages" "dist-packages" ; do
+                l="${BOB_ALL_PATHS[$i]}${PYTHON3_DESTLIB}${j:+/$j}"
+                if [[ -d "$l" ]] ; then
+                    PYTHONPATH+="${PYTHONPATH:+:}$l"
+                fi
+            done
+        done
+        export PYTHONPATH
+    fi


### PR DESCRIPTION
65cedc9 makes python usabe in checkoutScripts. This produces different checkoutVariants for recipes where the python part is only needed for one multiPackage but not for another:
```
checkoutSCM:
 ...

multiPackage:
    foo:

    python:
        inherit: [python3-usr]
```
Revert 65cedc9 and add a separate python3-usr-checkout class to avoid this.