### PR TITLE
strip: fix stripping of setuid ELF files

### DIFF
--- a/classes/strip.yaml
+++ b/classes/strip.yaml
@@ -8,7 +8,7 @@ packageSetup: |
         fi
 
         local type="$(file -b "$1")"
-        if [[ $type == ELF*not\ stripped ]] ; then
+        if [[ $type == *ELF*not\ stripped ]] ; then
             echo "Stripping ${1} ..."
 
             local dir="${1%/*}/.debug" file="${1##*/}"


### PR DESCRIPTION
The file command reports ELF files with the setuid bit is set as

setuid ELF 64-bit LSB pie executable [...] with debug_info, not stripped

Fix the condition to cover these as well.