### PR TITLE
python3::build: add option to build the wheel only

### DIFF
--- a/classes/python3/build.yaml
+++ b/classes/python3/build.yaml
@@ -6,10 +6,27 @@ depends:
 
 buildSetup: |
     python3Build () {
+        # parse arguments
+        OPTIND=1
+        local opt
+        local ARGS=()
+        while getopts "w" opt ; do
+            case "$opt" in
+                w)
+                    ARGS+=("--wheel")
+                    ;;
+                \?)
+                  echo "Invalid option: -$OPTARG" >&2
+                  exit 1
+                  ;;
+            esac
+        done
+        shift $(( OPTIND -1 ))
+
         rm -rf build install && mkdir -p build install
         pushd build
         rsync -a --delete $1/ .
-        python3 -m build -n .
+        python3 -m build -n ${ARGS[@]} .
         python3 -m installer dist/*.whl --prefix ../install/usr/
         popd
     }


### PR DESCRIPTION
Without any additional option both sdist and wheel are generated.