### PR TITLE
utils/unzip: Add patch to remove conflicting decls

### DIFF
--- a/recipes/utils/unzip/0002-no-time-conflicting-decls.patch
+++ b/recipes/utils/unzip/0002-no-time-conflicting-decls.patch
@@ -1,0 +1,10 @@
+--- a/unix/unxcfg.h
++++ b/unix/unxcfg.h
+@@ -118,7 +118,6 @@
+ #  endif
+ #else
+ #  include <time.h>
+-   struct tm *gmtime(), *localtime();
+ #endif
+ 
+ #if (defined(BSD4_4) || (defined(SYSV) && defined(MODERN)))


### PR DESCRIPTION
This addresses a build issue with gcc-15.