### PR TITLE
strip: fix strip of shared libraries

### DIFF
--- a/classes/strip.yaml
+++ b/classes/strip.yaml
@@ -24,7 +24,7 @@ packageSetup: |
             chmod u+w "$1"
 
             # shared libraries need to be treated with care
-            if [[ $1 == *.so* && $type == ELF*shared ]] ; then
+            if [[ $1 == *.so* && $type == ELF*shared* ]] ; then
                 $STRIP --remove-section=.comment --remove-section=.note \
                     --strip-unneeded "$1"
             else


### PR DESCRIPTION
The file command returns `ELF 64-bit LSB shared object, x86-64, [..]` for shared libraries. Fix the pattern to match this. Otherwise shared libraries might miss some symbols.