### PR TITLE
devel/compat/gcc: pass gmp/mpfr/mpc/isl paths to configure

### DIFF
--- a/recipes/devel/compat/gcc.yaml
+++ b/recipes/devel/compat/gcc.yaml
@@ -74,7 +74,15 @@ buildScript: |
                 --disable-documentation \
                 --disable-debug \
                 --with-xmlto=no \
-                --with-fop=no
+                --with-fop=no \
+                --with-gmp-include=${BOB_DEP_PATHS[libs::gmp-dev]}/usr/include \
+                --with-gmp-lib=${BOB_DEP_PATHS[libs::gmp-dev]}/usr/lib \
+                --with-mpfr-include=${BOB_DEP_PATHS[libs::mpfr-dev]}/usr/include \
+                --with-mpfr-lib=${BOB_DEP_PATHS[libs::mpfr-dev]}/usr/lib \
+                --with-mpc-include=${BOB_DEP_PATHS[libs::mpc-dev]}/usr/include \
+                --with-mpc-lib=${BOB_DEP_PATHS[libs::mpc-dev]}/usr/lib \
+                --with-isl-include=${BOB_DEP_PATHS[libs::compat::isl-dev]}/usr/include \
+                --with-isl-lib=${BOB_DEP_PATHS[libs::compat::isl-dev]}/usr/lib
             touch .configure.stamp
         fi
         makeParallel


### PR DESCRIPTION
Building `devel::compat::gcc-cross-bare` for aarch64 targets failed with:
```
    In file included from gcc/config/aarch64/aarch64-speculation.cc:22:
    gcc/system.h:687:10: fatal error: gmp.h: No such file or directory
```

The rules in `gcc/config/aarch64/t-aarch64` reference `$(ALL_SPPFLAGS)` instead of `$(ALL_CPPFLAGS)`. The undefined variable expands to nothing so the include paths that were passed via `CPPFLAGS` are dropped for these objects. The typo is still present in current GCC master.

Those rules do keep `$(INCLUDES)`, which contains `$(GMPINC)` and `$(ISLINC)`. Therefore locate the libraries the same way as the regular `gcc` recipe does, that is by telling configure explicitly where the headers and libraries are. This also removes a needless deviation between the two recipes.

Fixes #320