### PR TITLE
Fix host native cflags

### DIFF
--- a/classes/basement/bits/sandbox-toolchain.yaml
+++ b/classes/basement/bits/sandbox-toolchain.yaml
@@ -73,6 +73,7 @@ provideTools:
             GNU_LD: "ld"
 
             # meta information
+            ARCH: "${ARCH}"
             TOOLCHAIN_FLAVOUR: gcc
         fingerprintIf: True
         fingerprintScript: |

--- a/classes/basement/bits/sandbox-toolchain.yaml
+++ b/classes/basement/bits/sandbox-toolchain.yaml
@@ -49,7 +49,7 @@ packageScript: |
 
 provideTools:
     host-toolchain: "."
-    target-toolchain: &target-toolchain
+    target-toolchain:
         path: "."
         environment:
             # Default tool names.
@@ -76,13 +76,51 @@ provideTools:
             ARCH: "${ARCH}"
             TOOLCHAIN_FLAVOUR: gcc
         fingerprintIf: True
-        fingerprintScript: |
+        fingerprintScript: &fingerprint-script |
             # required for sandbox where gcc is not in PATH
             export PATH="$PATH:/toolchain/bin"
             bob-libc-version gcc
             bob-libstdc++-version g++
-    host-compat-toolchain: *target-toolchain
-    host-native-toolchain: *target-toolchain
+
+    host-compat-toolchain: &compat-toolchain
+        path: "."
+        environment:
+            # Default tool names.
+            AR: "ar"
+            AS: "as"
+            CC: "gcc"
+            CPP: "cpp"
+            CXX: "g++"
+            LD: "ld"
+            NM: "nm"
+            OBJCOPY: "objcopy"
+            OBJDUMP: "objdump"
+            RANLIB: "ranlib"
+            READELF: "readelf"
+            STRIP: "strip"
+
+            # Fallback variables for recipes that cannot work with clang.
+            GNU_CC: "gcc"
+            GNU_CPP: "cpp"
+            GNU_CXX: "g++"
+            GNU_LD: "ld"
+
+            # meta information
+            ARCH: "${ARCH}"
+            TOOLCHAIN_FLAVOUR: gcc
+
+            # Override compiler flags to mask active settings.
+            #
+            # Attention: keep in sync with default.yaml! These flags should be
+            # reset exactly to their default values.
+            CPPFLAGS:   ""
+            CFLAGS:     "-O2 -pipe -fPIC"
+            CXXFLAGS:   "-O2 -pipe -fPIC"
+            LDFLAGS:    ""
+        fingerprintIf: True
+        fingerprintScript: *fingerprint-script
+
+    host-native-toolchain: *compat-toolchain
 
 provideVars:
     # Define our own build-architecture. It is distinct from the host

--- a/default.yaml
+++ b/default.yaml
@@ -27,8 +27,10 @@ environment:
     # packages still build shared libraries, though. Make sure we compile
     # position independent code in case static and dynamic libraries are mixed.
     #
-    # Attention: keep in sync with devel::host-compat-toolchain! These flags
-    # should be reset by the compat-toolchain exactly to their default values.
+    # Attention: keep in sync with classes/basement/bits/sandbox-toolchain.yaml,
+    # recipes/devel/bootstrap-host-toolchain.yaml and
+    # recipes/devel/host-compat-toolchain.yaml!  These flags should be reset by
+    # the compat-toolchain exactly to their default values.
     CPPFLAGS:   ""
     CFLAGS:     "-O2 -pipe -fPIC"
     CXXFLAGS:   "-O2 -pipe -fPIC"

--- a/recipes/devel/bootstrap-host-toolchain.yaml
+++ b/recipes/devel/bootstrap-host-toolchain.yaml
@@ -4,7 +4,7 @@
 
 provideTools:
     host-toolchain: "."
-    target-toolchain: &target-toolchain
+    target-toolchain:
         path: "."
         environment:
             # Default tool names.
@@ -31,8 +31,46 @@ provideTools:
             ARCH: "${ARCH}"
             TOOLCHAIN_FLAVOUR: gcc
         fingerprintIf: True
-        fingerprintScript: |
+        fingerprintScript: &fingerprint-script |
             bob-libc-version gcc
             bob-libstdc++-version g++
-    host-compat-toolchain: *target-toolchain
-    host-native-toolchain: *target-toolchain
+
+    host-compat-toolchain: &compat-toolchain
+        path: "."
+        environment:
+            # Default tool names.
+            AR: "ar"
+            AS: "as"
+            CC: "gcc"
+            CPP: "cpp"
+            CXX: "g++"
+            LD: "ld"
+            NM: "nm"
+            OBJCOPY: "objcopy"
+            OBJDUMP: "objdump"
+            RANLIB: "ranlib"
+            READELF: "readelf"
+            STRIP: "strip"
+
+            # Fallback variables for recipes that cannot work with clang.
+            GNU_CC: "gcc"
+            GNU_CPP: "cpp"
+            GNU_CXX: "g++"
+            GNU_LD: "ld"
+
+            # meta information
+            ARCH: "${ARCH}"
+            TOOLCHAIN_FLAVOUR: gcc
+
+            # Override compiler flags to mask active settings.
+            #
+            # Attention: keep in sync with default.yaml! These flags should be
+            # reset exactly to their default values.
+            CPPFLAGS:   ""
+            CFLAGS:     "-O2 -pipe -fPIC"
+            CXXFLAGS:   "-O2 -pipe -fPIC"
+            LDFLAGS:    ""
+        fingerprintIf: True
+        fingerprintScript: *fingerprint-script
+
+    host-native-toolchain: *compat-toolchain

--- a/recipes/devel/bootstrap-host-toolchain.yaml
+++ b/recipes/devel/bootstrap-host-toolchain.yaml
@@ -28,6 +28,7 @@ provideTools:
             GNU_LD: "ld"
 
             # meta information
+            ARCH: "${ARCH}"
             TOOLCHAIN_FLAVOUR: gcc
         fingerprintIf: True
         fingerprintScript: |


### PR DESCRIPTION
Not all host-compat-toolchain instances and none of the host-native-toolchain's did reset the C/CPP/CXX/LD-FLAGS. This can lead to subtly different variants because some state of the current cross compiling toolchain leaks when pivoting to the compat toolchain.